### PR TITLE
Bugfix: clear background when changing image

### DIFF
--- a/Classes/Session/TSSTPageView.m
+++ b/Classes/Session/TSSTPageView.m
@@ -302,6 +302,9 @@ typedef struct {
 	NSImageInterpolation interpolation = [self inLiveResize] || scrollKeys ? NSImageInterpolationLow : NSImageInterpolationHigh;
 	[[NSGraphicsContext currentContext] setImageInterpolation: interpolation];
 	
+	self.layer.sublayers = nil;
+	self.layer.backgroundColor = [[NSColor blackColor]CGColor];
+	
 	NSData *firstPageImageData = firstPageImage.TIFFRepresentation;
     CGImageSourceRef firstPageImageSource = CGImageSourceCreateWithData((__bridge CFDataRef)firstPageImageData, NULL);
     CGImageRef firstPageImageRef =  CGImageSourceCreateImageAtIndex(firstPageImageSource, 0, NULL);

--- a/Classes/Session/TSSTPageView.m
+++ b/Classes/Session/TSSTPageView.m
@@ -303,7 +303,10 @@ typedef struct {
 	[[NSGraphicsContext currentContext] setImageInterpolation: interpolation];
 	
 	self.layer.sublayers = nil;
-	self.layer.backgroundColor = [[NSColor blackColor]CGColor];
+	
+	NSUserDefaults * defaults = [NSUserDefaults standardUserDefaults];
+	NSColor * color = [NSKeyedUnarchiver unarchiveObjectWithData: [defaults valueForKey: TSSTBackgroundColor]];
+	self.layer.backgroundColor = [color CGColor];
 	
 	NSData *firstPageImageData = firstPageImage.TIFFRepresentation;
     CGImageSourceRef firstPageImageSource = CGImageSourceCreateWithData((__bridge CFDataRef)firstPageImageData, NULL);


### PR DESCRIPTION
Fixes a bug introduced by previous commit: in full screen mode, when we display a new image with a smaller geometry than the previous image, parts of the previous image remain visible.