### PR TITLE
Implemented rotation, save alert and crop selection with CALayer.

### DIFF
--- a/Classes/Helpers/CenteredTextLayer.h
+++ b/Classes/Helpers/CenteredTextLayer.h
@@ -1,0 +1,17 @@
+//
+//  CenteredTextLayer.h
+//  Simple Comic
+//
+//  Created by Franco Solerio on 17/04/2020.
+//  Copyright © 2020 Dancing Tortoise Software. All rights reserved.
+//
+
+#import <QuartzCore/QuartzCore.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface CenteredTextLayer : CATextLayer
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Classes/Helpers/CenteredTextLayer.m
+++ b/Classes/Helpers/CenteredTextLayer.m
@@ -1,0 +1,24 @@
+//
+//  CenteredTextLayer.m
+//  Simple Comic
+//
+//  Created by Franco Solerio on 17/04/2020.
+//  Copyright © 2020 Dancing Tortoise Software. All rights reserved.
+//
+
+#import "CenteredTextLayer.h"
+
+@implementation CenteredTextLayer
+
+- (void)drawInContext:(CGContextRef)ctx {
+	CGFloat height = self.bounds.size.height;
+	CGFloat fontSize = self.fontSize;
+	CGFloat yDiff = (height-fontSize)/2 - fontSize/10;
+	
+	CGContextSaveGState(ctx);
+	CGContextTranslateCTM(ctx, 0, -yDiff);
+	[super drawInContext:ctx];
+	CGContextRestoreGState(ctx);
+}
+
+@end

--- a/Classes/Session/TSSTPageView.h
+++ b/Classes/Session/TSSTPageView.h
@@ -112,7 +112,11 @@ typedef NS_ENUM(NSInteger, DTPageScaling) {
 
 /*!	Concatinates an affine transform to the context.
 	This is what enables the page rotation. */
-- (void)rotationTransformWithFrame:(NSRect)rect;
+- (NSAffineTransform *)rotationTransformWithFrame:(NSRect)rect;
+
+/*!	Returns an affine transform to apply to a CALayer.
+This is what enables the page rotation. */
+- (CGAffineTransform)rotationCGTransformWithFrame:(NSRect)rect;
 
 @property (readonly) BOOL horizontalScrollIsPossible;
 @property (readonly) BOOL verticalScrollIsPossible;

--- a/Classes/Session/TSSTPageView.m
+++ b/Classes/Session/TSSTPageView.m
@@ -23,6 +23,7 @@
 #import "SimpleComicAppDelegate.h"
 #import "TSSTSessionWindowController.h"
 #import "TSSTManagedSession.h"
+#import "CenteredTextLayer.h"
 
 typedef NS_ENUM(int, TSSTTurn) {
 	TSSTTurnNone = 0,
@@ -372,29 +373,38 @@ typedef struct {
 		[highlight fill];
 	}
 	
+	NSColor* labelBackgroundColor;
 	if (@available(macOS 10.14, *)) {
-		[[NSColor.selectedContentBackgroundColor colorWithAlphaComponent:0.8] set];
+		labelBackgroundColor = [NSColor.selectedContentBackgroundColor colorWithAlphaComponent:0.8];
 	} else {
-		[[NSColor colorWithCalibratedWhite: .2 alpha: 0.8] set];
+		labelBackgroundColor = [NSColor colorWithCalibratedWhite: .2 alpha: 0.8];
 	}
 	
 	if([sessionController pageSelectionInProgress])
 	{
-		NSMutableParagraphStyle * style = [[NSParagraphStyle defaultParagraphStyle] mutableCopy];
-		[style setAlignment: NSTextAlignmentCenter];
-		NSDictionary * stringAttributes = @{NSFontAttributeName: [NSFont systemFontOfSize: 24],
-											NSForegroundColorAttributeName: [NSColor whiteColor],
-											NSParagraphStyleAttributeName: style};
 		NSString * selectionText = NSLocalizedString(@"Click to select page", @"");
 		if([sessionController pageSelectionCanCrop])
 		{
 			selectionText = [selectionText stringByAppendingString: NSLocalizedString(@"\nDrag to crop", @"")];
 		}
-		NSSize textSize = [selectionText sizeWithAttributes: stringAttributes];
-		NSRect bezelRect = rectWithSizeCenteredInRect(textSize, imageBounds);
-		NSBezierPath * bezel = roundedRectWithCornerRadius(NSInsetRect(bezelRect, -8, -4), 6);
-		[bezel fill];
-		[selectionText drawInRect: bezelRect withAttributes: stringAttributes];
+		
+		CenteredTextLayer *label = [[CenteredTextLayer alloc] init];
+		NSFont* labelFont = [NSFont systemFontOfSize: 24];
+		[label setFont: (__bridge CFTypeRef _Nullable)(labelFont)];
+		[label setFontSize: 24];
+		[label setAlignmentMode:kCAAlignmentCenter];
+		[label setString:selectionText];
+		
+		NSRect labelRect = rectWithSizeCenteredInRect(label.preferredFrameSize, imageBounds);
+		NSRect layerRect = CGRectInset(labelRect, -4, -4);
+		
+		[label setFrame: layerRect];
+		
+		[label setBackgroundColor: [labelBackgroundColor CGColor]];
+		[label setForegroundColor:[[NSColor whiteColor] CGColor]];
+		[label setCornerRadius: 6];
+		
+		[self.layer addSublayer:label];
 	}
 	
 	[NSGraphicsContext restoreGraphicsState];

--- a/Classes/Session/TSSTPageView.m
+++ b/Classes/Session/TSSTPageView.m
@@ -416,9 +416,12 @@ typedef struct {
 	
 	if(acceptingDrag)
 	{
-		[NSBezierPath setDefaultLineWidth: 6];
-		[[NSColor keyboardFocusIndicatorColor] set];
-		[NSBezierPath strokeRect: [[self enclosingScrollView] documentVisibleRect]];
+		CALayer* selectionLayer = [[CALayer alloc]init];
+		[selectionLayer setBorderWidth:6.0];
+		[selectionLayer setBorderColor:[[NSColor keyboardFocusIndicatorColor]CGColor]];
+		CGRect frame = self.enclosingScrollView.documentVisibleRect;
+		[selectionLayer setFrame: frame];
+		[self.layer addSublayer:selectionLayer];
 	}
 }
 

--- a/SimpleComic.xcodeproj/project.pbxproj
+++ b/SimpleComic.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		28C1D5600DF1FE37003392B4 /* QuickLook.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28C1D55F0DF1FE37003392B4 /* QuickLook.framework */; };
 		28EF3FC00E9970BD002AD2EE /* UKXattrMetadataStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 28EF3FBF0E9970BD002AD2EE /* UKXattrMetadataStore.m */; };
 		28F660461067255600EC8A34 /* Help in Resources */ = {isa = PBXBuildFile; fileRef = 28F6603B1067255600EC8A34 /* Help */; };
+		42D9A8BF2449ABC400AF2FB6 /* CenteredTextLayer.m in Sources */ = {isa = PBXBuildFile; fileRef = 42D9A8BE2449ABC400AF2FB6 /* CenteredTextLayer.m */; };
 		5500A65C1D7772B200321300 /* XADMaster.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5500A6371D77712F00321300 /* XADMaster.framework */; };
 		5500A65D1D7772CD00321300 /* XADMaster.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5500A6371D77712F00321300 /* XADMaster.framework */; };
 		5500A65F1D7772D400321300 /* XADMaster.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 5500A6371D77712F00321300 /* XADMaster.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -293,6 +294,8 @@
 		29B97324FDCFA39411CA2CEA /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = System/Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
 		29B97325FDCFA39411CA2CEA /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		32CA4F630368D1EE00C91783 /* SimpleComic_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SimpleComic_Prefix.pch; sourceTree = "<group>"; };
+		42D9A8BD2449ABC400AF2FB6 /* CenteredTextLayer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CenteredTextLayer.h; sourceTree = "<group>"; };
+		42D9A8BE2449ABC400AF2FB6 /* CenteredTextLayer.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CenteredTextLayer.m; sourceTree = "<group>"; };
 		5500A6231D77712F00321300 /* XADMaster.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = XADMaster.xcodeproj; path = Vendor/XADMaster/XADMaster.xcodeproj; sourceTree = "<group>"; };
 		551361B32399B97D002BA9BF /* Sessions_DataModel 2.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Sessions_DataModel 2.xcdatamodel"; sourceTree = "<group>"; };
 		5518C6A81BDAABA600D50302 /* ja */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/MainMenu.strings; sourceTree = "<group>"; };
@@ -446,6 +449,8 @@
 				286AEDB60C4161C20031E3D9 /* TSSTSortDescriptor.m */,
 				280FB7A50CD577730053F375 /* TSSTCustomValueTransformers.h */,
 				FA9FB53408AADA270085AA55 /* TSSTCustomValueTransformers.m */,
+				42D9A8BD2449ABC400AF2FB6 /* CenteredTextLayer.h */,
+				42D9A8BE2449ABC400AF2FB6 /* CenteredTextLayer.m */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -948,6 +953,7 @@
 				28EF3FC00E9970BD002AD2EE /* UKXattrMetadataStore.m in Sources */,
 				55FFF1BE1DB01C5E0080B059 /* TSSTPage+CoreDataProperties.m in Sources */,
 				284D381B101249BE00A37AB2 /* DTToolbarItems.m in Sources */,
+				42D9A8BF2449ABC400AF2FB6 /* CenteredTextLayer.m in Sources */,
 				55FFF1DF1DB020470080B059 /* TSSTManagedGroup+CoreDataProperties.m in Sources */,
 				55FFF1E61DB0275C0080B059 /* TSSTManagedSession+CoreDataProperties.m in Sources */,
 				5538C2021C0E1A7C00744130 /* TSSTInfoView.swift in Sources */,


### PR DESCRIPTION
The previous implementations of save alert and crop selection where displayed on the view's main CALayer, that is now hidden behind the new sublayer with the images. We are now drawing the alert and selection graphics on a sublayer, so they are visible over the image.

The rotated images are now rendered on a CALayer sublayer too.