### PR TITLE
Fallback to drawInRect in case TIFFRepresentation fails

### DIFF
--- a/Classes/Session/TSSTPageView.m
+++ b/Classes/Session/TSSTPageView.m
@@ -309,28 +309,46 @@ typedef struct {
 	self.layer.backgroundColor = [color CGColor];
 
 	NSData *firstPageImageData = firstPageImage.TIFFRepresentation;
-    CGImageSourceRef firstPageImageSource = CGImageSourceCreateWithData((__bridge CFDataRef)firstPageImageData, NULL);
-    CGImageRef firstPageImageRef =  CGImageSourceCreateImageAtIndex(firstPageImageSource, 0, NULL);
-	CFRelease(firstPageImageSource);
 
-	CALayer *firstPageLayer = [CALayer layer];
-	firstPageLayer.contents = (__bridge id) firstPageImageRef;
-	[firstPageLayer setFrame:[self centerScanRect: firstPageRect]];
-	[newLayer addSublayer:firstPageLayer];
-	CFRelease(firstPageImageRef);
+	if(firstPageImageData != nil)
+	{
+		CGImageSourceRef firstPageImageSource = CGImageSourceCreateWithData((__bridge CFDataRef)firstPageImageData, NULL);
+		CGImageRef firstPageImageRef =  CGImageSourceCreateImageAtIndex(firstPageImageSource, 0, NULL);
+		CFRelease(firstPageImageSource);
+
+		CALayer *firstPageLayer = [CALayer layer];
+		firstPageLayer.contents = (__bridge id) firstPageImageRef;
+		[firstPageLayer setFrame:[self centerScanRect: firstPageRect]];
+		[newLayer addSublayer:firstPageLayer];
+		CFRelease(firstPageImageRef);
+	} else {
+		[firstPageImage drawInRect: [self centerScanRect: firstPageRect]
+						  fromRect: NSZeroRect
+						 operation: NSCompositingOperationSourceOver
+						  fraction: 1.0];
+	}
 
 	if([secondPageImage isValid])
 	{
 		NSData *secondPageImageData = secondPageImage.TIFFRepresentation;
-		CGImageSourceRef secondPageImageSource = CGImageSourceCreateWithData((__bridge CFDataRef)secondPageImageData, NULL);
-		CGImageRef secondPageImageRef =  CGImageSourceCreateImageAtIndex(secondPageImageSource, 0, NULL);
-		CFRelease(secondPageImageSource);
 
-		CALayer *secondPageLayer = [CALayer layer];
-		secondPageLayer.contents = (__bridge id) secondPageImageRef;
-		[secondPageLayer setFrame:[self centerScanRect: secondPageRect]];
-		[newLayer addSublayer:secondPageLayer];
-		CFRelease(secondPageImageRef);
+		if(secondPageImageData != nil)
+		{
+			CGImageSourceRef secondPageImageSource = CGImageSourceCreateWithData((__bridge CFDataRef)secondPageImageData, NULL);
+			CGImageRef secondPageImageRef =  CGImageSourceCreateImageAtIndex(secondPageImageSource, 0, NULL);
+			CFRelease(secondPageImageSource);
+
+			CALayer *secondPageLayer = [CALayer layer];
+			secondPageLayer.contents = (__bridge id) secondPageImageRef;
+			[secondPageLayer setFrame:[self centerScanRect: secondPageRect]];
+			[newLayer addSublayer:secondPageLayer];
+			CFRelease(secondPageImageRef);
+		} else {
+			[secondPageImage drawInRect: [self centerScanRect: secondPageRect]
+							   fromRect: NSZeroRect
+							  operation: NSCompositingOperationSourceOver
+							   fraction: 1.0];
+		}
 	}
 	
 	NSColor* selectionBackgroundColor;


### PR DESCRIPTION
This PR makes handling of invalid and malformed images more graceful.

I encountered some application crashes when attempting to view the contents of [this](https://www.dropbox.com/s/8bu2ihlreiag4m1/Oshi%20no%20Ko%20c001%20[Jaimini's~box~].zip?dl=1) manga chapter archive. 

After some digging, turns out that these crashes were caused by `[NSImage TIFFRepresentation]` returning `nil` for every image that fails to be successfully decoded and converted, resulting in an unhandled exception.

`drawInRect` on the other hand displays partially decoded images, which at the very least gives the user an indication that there's a problem related to image loading, and allows them to proceed to the next image.