### PR TITLE
Bug Fix: Cursor changes from open hand to close hand at the start of …

### DIFF
--- a/Classes/Session/TSSTPageView.m
+++ b/Classes/Session/TSSTPageView.m
@@ -61,6 +61,9 @@ typedef struct {
 	
 	//! This controls the drawing of the accepting drag-drop border highlighting
 	BOOL acceptingDrag;
+
+	/// YES while we are actively dragging
+	BOOL isInDrag;
 	
 	/*!	While page selection is in progress this method has a value of 1 or 2.
 	 The selection number coresponds to a highlighted page. */
@@ -1352,6 +1355,7 @@ typedef struct {
 	}
 	else if([self dragIsPossible])
 	{
+		isInDrag = YES;
 		while ([theEvent type] != NSEventTypeLeftMouseUp)
 		{
 			if ([theEvent type] == NSEventTypeLeftMouseDragged)
@@ -1362,6 +1366,7 @@ typedef struct {
 			}
 			theEvent = [[self window] nextEventMatchingMask: NSEventMaskLeftMouseUp | NSEventMaskLeftMouseDragged];
 		}
+		isInDrag = NO;
 		[[self window] invalidateCursorRectsForView: self];
 	}
 }
@@ -1498,7 +1503,8 @@ typedef struct {
 {
 	if([self dragIsPossible])
 	{
-		[self addCursorRect: [[self enclosingScrollView] documentVisibleRect] cursor: [NSCursor openHandCursor]];
+		NSCursor *cursor = isInDrag ? [NSCursor closedHandCursor] : [NSCursor openHandCursor];
+		[self addCursorRect: [[self enclosingScrollView] documentVisibleRect] cursor: cursor];
 	}
 //	else if(canCrop)
 //	{


### PR DESCRIPTION
…a drag, but before this, it didn't stay a closed hand for the duration of the drag.

To see the bug: 
shrink the window so you have scroll bars. Mouse over the window, note the open hand cursor.
click and hold in the window, but don't move the mouse. note the cursor is now closed hand.
drag: cursor should stay closed hand for the duration of the drag. It doesn't: it incorrectly changes to open hand.