### PR TITLE
OCR - fix issue: Live Text in Simple Comic #69

### DIFF
--- a/Classes/Session/OCRVision/OCRSelectionLayer.h
+++ b/Classes/Session/OCRVision/OCRSelectionLayer.h
@@ -1,0 +1,16 @@
+//  OCRSelectionLayer.h
+//
+//  Created by David Phillip Oster on 5/26/2022 Apache Version 2 open source license.
+//
+
+#import <Cocoa/Cocoa.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// The layer that displays the hilite of the selected text. For internal use by OCRTracker.
+API_AVAILABLE(macos(10.15))
+@interface OCRSelectionLayer : CALayer
+- (instancetype)initWithObservations:(NSArray *)observations selection:(NSDictionary *)selection imageLayer:(CALayer *)imageLayer;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Classes/Session/OCRVision/OCRSelectionLayer.h
+++ b/Classes/Session/OCRVision/OCRSelectionLayer.h
@@ -4,12 +4,13 @@
 //
 
 #import <Cocoa/Cocoa.h>
+#import <QuartzCore/QuartzCore.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 /// The layer that displays the hilite of the selected text. For internal use by OCRTracker.
 API_AVAILABLE(macos(10.15))
-@interface OCRSelectionLayer : CALayer
+@interface OCRSelectionLayer : CAShapeLayer
 - (instancetype)initWithObservations:(NSArray *)observations selection:(NSDictionary *)selection imageLayer:(CALayer *)imageLayer;
 @end
 

--- a/Classes/Session/OCRVision/OCRSelectionLayer.m
+++ b/Classes/Session/OCRVision/OCRSelectionLayer.m
@@ -1,0 +1,78 @@
+//  OCRSelectionLayer.m
+//
+//  Created by David Phillip Oster on 5/26/2022 Apache Version 2 open source license.
+//
+
+#import "OCRSelectionLayer.h"
+
+#import "OCRTracker.h"
+#import <Vision/Vision.h>
+
+static CGPathRef CGPathFromNSBezierQuadPath(NSBezierPath *path)
+{
+	CGMutablePathRef p = CGPathCreateMutable();
+	NSInteger numElements = [path elementCount];
+	NSPoint points[3];
+	for (NSInteger i = 0; i < numElements; i++)
+	{
+		switch ([path elementAtIndex:i associatedPoints:points])
+		{
+			case NSMoveToBezierPathElement:
+				CGPathMoveToPoint(p, NULL, points[0].x, points[0].y);
+				break;
+			case NSLineToBezierPathElement:
+				CGPathAddLineToPoint(p, NULL, points[0].x, points[0].y);
+				break;
+			case NSBezierPathElementClosePath:
+				CGPathCloseSubpath(p);
+				break;
+			default:
+				break;
+		}
+	}
+	return p;
+}
+
+@interface OCRSelectionLayer ()
+@property NSArray *textPieces;
+@property NSDictionary *selection;
+@end
+
+@implementation OCRSelectionLayer
+- (instancetype)initWithObservations:(NSArray *)observations selection:(NSDictionary *)selection  imageLayer:(CALayer *)imageLayer
+{
+	self = [super init];
+	if (self) {
+		_textPieces = observations;
+		_selection = selection;
+		[self setPosition:imageLayer.position];
+		[self setBounds:imageLayer.bounds];
+		[self setNeedsDisplay];
+	}
+	return self;
+}
+
+- (void)drawInContext:(CGContextRef)ctx
+{
+	CGContextSaveGState(ctx);
+	CGContextSetFillColorWithColor(ctx, [[NSColor.yellowColor colorWithAlphaComponent:0.4] CGColor]);
+	NSAffineTransform *transform = [NSAffineTransform transform];
+	[transform scaleXBy:self.bounds.size.width yBy:self.bounds.size.height];
+	for (VNRecognizedTextObservation *piece in self.textPieces)
+	{
+		NSValue *rangeValue = self.selection[piece];
+		if (rangeValue != nil)
+		{
+			NSBezierPath *path1 = OCRBezierPathFromTextObservationRange(piece, rangeValue.rangeValue);
+			[path1 transformUsingAffineTransform:transform];
+			CGPathRef p = CGPathFromNSBezierQuadPath(path1);
+			CGContextAddPath(ctx, p);
+			CGContextFillPath(ctx);
+			CGPathRelease(p);
+		}
+	}
+	CGContextRestoreGState(ctx);
+}
+
+@end
+

--- a/Classes/Session/OCRVision/OCRSelectionLayer.m
+++ b/Classes/Session/OCRVision/OCRSelectionLayer.m
@@ -35,12 +35,13 @@ static CGPathRef CGPathFromNSBezierQuadPath(NSBezierPath *path)
 
 @implementation OCRSelectionLayer
 
-- (instancetype)initWithObservations:(NSArray *)observations selection:(NSDictionary *)selection  imageLayer:(CALayer *)imageLayer
+- (instancetype)initWithObservations:(NSArray *)observations selection:(NSDictionary *)selection imageLayer:(CALayer *)imageLayer
 {
 	self = [super init];
 	if (self) {
 		[self setPosition:imageLayer.position];
 		[self setBounds:imageLayer.bounds];
+		[self setFrame:imageLayer.bounds];
 		NSAffineTransform *transform = [NSAffineTransform transform];
 		[transform scaleXBy:self.bounds.size.width yBy:self.bounds.size.height];
 		self.fillColor = [NSColor.controlAccentColor CGColor];
@@ -60,8 +61,6 @@ static CGPathRef CGPathFromNSBezierQuadPath(NSBezierPath *path)
 		}
 		self.path = pAll;
 		CGPathRelease(pAll);
-
-		[self setNeedsDisplay];
 	}
 	return self;
 }

--- a/Classes/Session/OCRVision/OCRSelectionLayer.m
+++ b/Classes/Session/OCRVision/OCRSelectionLayer.m
@@ -55,7 +55,7 @@ static CGPathRef CGPathFromNSBezierQuadPath(NSBezierPath *path)
 - (void)drawInContext:(CGContextRef)ctx
 {
 	CGContextSaveGState(ctx);
-	CGContextSetFillColorWithColor(ctx, [[NSColor.yellowColor colorWithAlphaComponent:0.4] CGColor]);
+	CGContextSetFillColorWithColor(ctx, [[NSColor.controlAccentColor colorWithAlphaComponent:0.5] CGColor]);
 	NSAffineTransform *transform = [NSAffineTransform transform];
 	[transform scaleXBy:self.bounds.size.width yBy:self.bounds.size.height];
 	for (VNRecognizedTextObservation *piece in self.textPieces)

--- a/Classes/Session/OCRVision/OCRTracker.h
+++ b/Classes/Session/OCRVision/OCRTracker.h
@@ -18,11 +18,14 @@ NS_ASSUME_NONNULL_BEGIN
 /// all the text on the page. nil if not available.
 @property(readonly, nullable) NSString *allText;
 
-/// Run the ocr engine on the image in the default language.
-- (void)ocrImage:(NSImage *)image;
+/// Run the ocr engine on the first page image in the default language.
+/// @param image - OCRed, then used as a cache key for mouse tracking the result. Pass nil to clear the cache entry
+- (void)ocrImage:(nullable NSImage *)image;
 
-/// Run the ocr engine on the CGimage in the default language.
-- (void)ocrCGImage:(CGImageRef)cgImage;
+/// Run the ocr engine on the second page image in the default language.
+/// @param image - OCRed, then used as a cache key for mouse tracking the result. Pass nil to clear the cache entry
+- (void)ocrImage2:(nullable NSImage *)image;
+
 
 - (instancetype)initWithView:(NSView *)view NS_DESIGNATED_INITIALIZER;
 

--- a/Classes/Session/OCRVision/OCRTracker.h
+++ b/Classes/Session/OCRVision/OCRTracker.h
@@ -1,0 +1,51 @@
+//  OCRTracker.h
+//  MockSimpleComic
+//
+//  Created by David Phillip Oster on 5/21/2022 Apache Version 2 open source license.
+//
+
+#import <Cocoa/Cocoa.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Provide mouse tracking services for an NSImageView to track the recognized text.
+@interface OCRTracker : NSResponder
+
+/// The selected text as a single string. Readonly, because it is selected using the mouse. nil if not available.
+@property(readonly, nullable) NSString *selection;
+
+/// all the text on the page. nil if not available.
+@property(readonly, nullable) NSString *allText;
+
+/// Run the ocr engine on the image in the default language.
+- (void)ocrImage:(NSImage *)image;
+
+/// Run the ocr engine on the CGimage in the default language.
+- (void)ocrCGImage:(CGImageRef)cgImage;
+
+- (instancetype)initWithView:(NSView *)view NS_DESIGNATED_INITIALIZER;
+
+- (instancetype)init NS_UNAVAILABLE;
+
+- (instancetype)initWithCoder:(NSCoder *)coder NS_UNAVAILABLE;
+
+#pragma  mark -
+
+/// After owning views, call this to draw the selection as a tint on the view.
+- (void)drawRect:(NSRect)dirtyRect;
+
+/// return YES if this handles the mouse down.
+- (BOOL)didMouseDown:(NSEvent *)theEvent;
+
+/// return YES if this handles the mouse drag.
+- (BOOL)didMouseDragged:(NSEvent *)theEvent;
+
+/// return YES if this handles setting the cursor rects.
+- (BOOL)didResetCursorRects;
+
+/// When owning view becomes first responder, call this so it is next.
+- (void)becomeNextResponder;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Classes/Session/OCRVision/OCRTracker.h
+++ b/Classes/Session/OCRVision/OCRTracker.h
@@ -1,5 +1,4 @@
 //  OCRTracker.h
-//  MockSimpleComic
 //
 //  Created by David Phillip Oster on 5/21/2022 Apache Version 2 open source license.
 //
@@ -7,6 +6,8 @@
 #import <Cocoa/Cocoa.h>
 
 NS_ASSUME_NONNULL_BEGIN
+
+@class VNRecognizedTextObservation;
 
 /// Provide mouse tracking services for an NSImageView to track the recognized text.
 @interface OCRTracker : NSResponder
@@ -31,21 +32,34 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma  mark -
 
-/// After owning views, call this to draw the selection as a tint on the view.
-- (void)drawRect:(NSRect)dirtyRect;
+///
+/// @param image the key for the cached selection
+/// @param imageLayer the layer that draws the CGmage
+/// @return The layer that draws the hiliting of the selected text.
+- (nullable CALayer *)layerForImage:(NSImage *)image imageLayer:(CALayer *)imageLayer;
 
-/// return YES if this handles the mouse down.
+/// @return YES if this handles the mouse down.
 - (BOOL)didMouseDown:(NSEvent *)theEvent;
 
-/// return YES if this handles the mouse drag.
+/// @return YES if this handles the mouse drag.
 - (BOOL)didMouseDragged:(NSEvent *)theEvent;
 
-/// return YES if this handles setting the cursor rects.
+/// @return YES if this handles setting the cursor rects.
 - (BOOL)didResetCursorRects;
 
-/// When owning view becomes first responder, call this so it is next.
+/// When owning view becomes first responder, call this so this object is next.
 - (void)becomeNextResponder;
 
 @end
+
+///  Get the bezierPath of a part of a text observation.
+///
+///  Used by both OCRTtracker and OCRSelectionLayer
+///
+/// @param piece - the TextObservation
+/// @param r - the range of the string of the TextObservation
+/// @return the quadrilateral of the text observation as a NSBezierPath/
+API_AVAILABLE(macos(10.15))
+NSBezierPath *OCRBezierPathFromTextObservationRange(VNRecognizedTextObservation *piece, NSRange r);
 
 NS_ASSUME_NONNULL_END

--- a/Classes/Session/OCRVision/OCRTracker.m
+++ b/Classes/Session/OCRVision/OCRTracker.m
@@ -66,8 +66,12 @@ static NSRange UnionRanges(NSRange early, NSRange late)
 
 static NSSpeechSynthesizer *sSpeechSynthesizer;
 
-@interface OCRTracker()
-@property BOOL isDragging;
+/// Bundle up all the data associated with our client's image.
+@interface OCRDatum : NSObject
+
+@property(weak) NSImage *image;
+
+@property(weak) CALayer *selectionLayer;
 
 /// <VNRecognizedTextObservation *> - 10.15 and newer
 @property NSArray *textPieces;
@@ -75,6 +79,15 @@ static NSSpeechSynthesizer *sSpeechSynthesizer;
 // Key is VNRecognizedTextObservation.
 // The value is the NSRange of the underlying string to show as selected.
 @property NSMutableDictionary<NSObject *, NSValue *> *selectionPieces;
+@end
+
+@implementation OCRDatum
+@end
+
+@interface OCRTracker()
+@property BOOL isDragging;
+
+@property NSArray<OCRDatum *> *datums;
 
 @property (weak, nullable) NSView *view;
 
@@ -88,6 +101,10 @@ static NSSpeechSynthesizer *sSpeechSynthesizer;
 	if (self)
 	{
 		_view = view;
+		_datums = @[
+			[[OCRDatum alloc] init],
+			[[OCRDatum alloc] init],
+		];
 	}
 	return self;
 }
@@ -105,18 +122,80 @@ static NSSpeechSynthesizer *sSpeechSynthesizer;
   return YES;
 }
 
+- (OCRDatum *)datumOfImage:(NSImage *)image
+{
+	for (OCRDatum *datum in self.datums) {
+		if (datum.image == image) {
+			return datum;
+		}
+	}
+	return nil;
+}
+
+- (BOOL)isAnySelected {
+	for (OCRDatum *datum in self.datums)
+	{
+		if (datum.image != nil && datum.selectionPieces.count != 0)
+		{
+			return YES;
+		}
+	}
+	return NO;
+}
+
+- (NSInteger)totalTextPiecesCount
+{
+	NSInteger total = 0;
+	for (OCRDatum *datum in self.datums)
+	{
+		if (datum.image != nil) {
+			total += datum.textPieces.count;
+		}
+	}
+	return total;
+}
+
+- (NSInteger)totalSelectionPiecesCount
+{
+	NSInteger total = 0;
+	for (OCRDatum *datum in self.datums)
+	{
+		if (datum.image != nil) {
+			total += datum.selectionPieces.count;
+		}
+	}
+	return total;
+}
+
+- (void)addSelectionPiecesFromDictionary:(NSDictionary *)previousSelection API_AVAILABLE(macos(10.15))
+{
+	for (VNRecognizedTextObservation *textPiece in previousSelection.allKeys)
+	{
+		for (OCRDatum *datum in self.datums)
+		{
+			if (datum.image != nil && [datum.textPieces containsObject:textPiece]) {
+				datum.selectionPieces[textPiece] = previousSelection[textPiece];
+				break;
+			}
+		}
+	}
+}
+
+
 /// @return a layer of the selection for image scaled to frame.
 - (nullable CALayer *)layerForImage:(NSImage *)image imageLayer:(CALayer *)imageLayer {
 	CALayer *layer = nil;
 	if (@available(macOS 10.15, *))
 	{
-		if (self.textPieces != nil)
+		OCRDatum *datum = [self datumOfImage:image];
+		if (datum.image != nil && datum.textPieces != nil)
 		{
-			return [[OCRSelectionLayer alloc] initWithObservations:self.textPieces selection:self.selectionPieces imageLayer:imageLayer];
+			OCRSelectionLayer *selectionLayer =  [[OCRSelectionLayer alloc] initWithObservations:datum.textPieces selection:datum.selectionPieces imageLayer:imageLayer];
+			datum.selectionLayer = selectionLayer;
+			return selectionLayer;
 		}
 	}
 	return layer;
-
 }
 
 #pragma mark Model
@@ -126,10 +205,16 @@ static NSSpeechSynthesizer *sSpeechSynthesizer;
 	if (@available(macOS 10.15, *))
 	{
 		NSMutableArray *a = [NSMutableArray array];
-		for (VNRecognizedTextObservation *piece in self.textPieces)
+		for (OCRDatum *datum in self.datums)
 		{
-			NSArray<VNRecognizedText *> *text1 = [piece topCandidates:1];
-			[a addObject:text1.firstObject.string];
+			if (datum.image != nil)
+			{
+				for (VNRecognizedTextObservation *piece in datum.textPieces)
+				{
+					NSArray<VNRecognizedText *> *text1 = [piece topCandidates:1];
+					[a addObject:text1.firstObject.string];
+				}
+			}
 		}
 		return [a componentsJoinedByString:@"\n"];
 	}
@@ -141,15 +226,21 @@ static NSSpeechSynthesizer *sSpeechSynthesizer;
 	NSMutableArray *a = [NSMutableArray array];
 	if (@available(macOS 10.15, *))
 	{
-		for (VNRecognizedTextObservation *piece in self.textPieces)
+		for (OCRDatum *datum in self.datums)
 		{
-			NSValue *rangeInAValue = self.selectionPieces[piece];
-			if (rangeInAValue != nil)
+			if (datum.image != nil)
 			{
-				NSArray<VNRecognizedText *> *text1 = [piece topCandidates:1];
-				NSString *s = text1.firstObject.string;
-				s = [s substringWithRange:[rangeInAValue rangeValue]];
-				[a addObject:s];
+				for (VNRecognizedTextObservation *piece in datum.textPieces)
+				{
+					NSValue *rangeInAValue = datum.selectionPieces[piece];
+					if (rangeInAValue != nil)
+					{
+						NSArray<VNRecognizedText *> *text1 = [piece topCandidates:1];
+						NSString *s = text1.firstObject.string;
+						s = [s substringWithRange:[rangeInAValue rangeValue]];
+						[a addObject:s];
+					}
+				}
 			}
 		}
 	}
@@ -170,15 +261,21 @@ static NSSpeechSynthesizer *sSpeechSynthesizer;
 {
 	if (@available(macOS 10.15, *))
 	{
-		if (self.textPieces)
+		for (OCRDatum *datum in self.datums)
 		{
-			CGRect container = [[[self view] enclosingScrollView] documentVisibleRect];
-			for (VNRecognizedTextObservation *piece in self.textPieces)
+			if (datum.image != nil && datum.textPieces)
 			{
-				CGRect r = [self boundBoxOfPiece:piece];
-				r = CGRectIntersection(r, container);
-				if (!CGRectIsEmpty(r) && CGRectContainsPoint(r, where)) {
-					return piece;
+				CGRect container = [[[self view] enclosingScrollView] documentVisibleRect];
+				CGSize imageSize = datum.selectionLayer.bounds.size;
+				for (VNRecognizedTextObservation *piece in datum.textPieces)
+				{
+					CGRect r = VNImageRectForNormalizedRect(piece.boundingBox, imageSize.width, imageSize.height);
+					r = [datum.selectionLayer convertRect:r toLayer:self.view.layer];
+					r = CGRectIntersection(r, container);
+					if (!CGRectIsEmpty(r) && CGRectContainsPoint(r, where))
+					{
+						return piece;
+					}
 				}
 			}
 		}
@@ -186,25 +283,11 @@ static NSSpeechSynthesizer *sSpeechSynthesizer;
 	return nil;
 }
 
-/// Return the boundbox of a piece in View coordinates
-///
-/// @param piece - A text piece
-/// @return The bound box in View coordinates
-- (CGRect)boundBoxOfPiece:(VNRecognizedTextObservation *)piece API_AVAILABLE(macos(10.15))
-{
-	NSAffineTransform *transform = [NSAffineTransform transform];
-	[transform scaleXBy:self.view.bounds.size.width yBy:self.view.bounds.size.height];
-	CGRect r = piece.boundingBox;
-	r.origin = [transform transformPoint:r.origin];
-	r.size = [transform transformSize:r.size];
-	return r;
-}
-
 /// Return the boundbox of a range of a piece in View coordinates
 ///
 /// @param piece - A text piece
 /// @param charRange - the range within the piece.
-/// @return The bound box in View coordinates
+/// @return The bound box in VNRecognizedTextObservation coordinates
 - (CGRect)boundBoxOfPiece:(VNRecognizedTextObservation *)piece range:(NSRange)charRange API_AVAILABLE(macos(10.15))
 {
 	VNRecognizedText *text1 = [[piece topCandidates:1] firstObject];
@@ -214,13 +297,8 @@ static NSSpeechSynthesizer *sSpeechSynthesizer;
 		return CGRectNull;
 	}
 
-	NSAffineTransform *transform = [NSAffineTransform transform];
-	[transform scaleXBy:self.view.bounds.size.width yBy:self.view.bounds.size.height];
 	NSBezierPath *path = OCRBezierPathFromTextObservationRange(piece, charRange);
-	CGRect r = path.bounds;
-	r.origin = [transform transformPoint:r.origin];
-	r.size = [transform transformSize:r.size];
-	return r;
+	return path.bounds;
 }
 
 
@@ -230,7 +308,7 @@ static NSSpeechSynthesizer *sSpeechSynthesizer;
 ///
 ///  Since this will affect the U.I., sets state on the main thread.
 /// @param results -  the OCR's results object.
-- (void)ocrDidFinish:(id<OCRVisionResults>)results
+- (void)ocrDidFinish:(id<OCRVisionResults>)results image:(NSImage *)image index:(NSInteger)index
 {
 	NSArray *textPieces = @[];
 	if (@available(macOS 10.15, *)) {
@@ -240,37 +318,43 @@ static NSSpeechSynthesizer *sSpeechSynthesizer;
 	// but `complete` isn't guaranteed to exist then, so we assign to locals so it will be captured
 	// by the block.
 	dispatch_async(dispatch_get_main_queue(), ^{
-		self.textPieces = textPieces;
-		[self.selectionPieces removeAllObjects];
+		OCRDatum *datum = self.datums[index];
+		datum.image = image;
+		datum.textPieces = textPieces;
+		[datum.selectionPieces removeAllObjects];
 		[self.view setNeedsDisplay:YES];
 		[self.view.window invalidateCursorRectsForView:self.view];
 	});
 }
 
-- (void)ocrImage:(NSImage *)image
+- (void)ocrImage:(NSImage *)image index:(NSInteger)index
 {
 	if (@available(macOS 10.15, *)) {
-		__block OCRVision *ocrVision = [[OCRVision alloc] init];
-		dispatch_async(dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0), ^{
-			[ocrVision ocrImage:image completion:^(id<OCRVisionResults> _Nonnull complete) {
-				[self ocrDidFinish:complete];
-				ocrVision = nil;
-			}];
-		});
+		OCRDatum *datum = self.datums[index];
+		datum.image = nil;
+		datum.textPieces = @[];
+		[datum.selectionPieces removeAllObjects];
+		if (image)
+		{
+			__block OCRVision *ocrVision = [[OCRVision alloc] init];
+			dispatch_async(dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0), ^{
+				[ocrVision ocrImage:image completion:^(id<OCRVisionResults> _Nonnull complete) {
+					[self ocrDidFinish:complete image:image index:index];
+					ocrVision = nil;
+				}];
+			});
+		}
 	}
 }
 
-- (void)ocrCGImage:(CGImageRef)cgImage
+- (void)ocrImage:(NSImage *)image
 {
-	if (@available(macOS 10.15, *)) {
-		__block OCRVision *ocrVision = [[OCRVision alloc] init];
-		dispatch_async(dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0), ^{
-			[ocrVision ocrCGImage:cgImage completion:^(id<OCRVisionResults> _Nonnull complete) {
-				[self ocrDidFinish:complete];
-				ocrVision = nil;
-			}];
-		});
-	}
+	[self ocrImage:image index:0];
+}
+
+- (void)ocrImage2:(NSImage *)image
+{
+	[self ocrImage:image index:1];
 }
 
 
@@ -285,32 +369,47 @@ static NSSpeechSynthesizer *sSpeechSynthesizer;
 	BOOL isDoingMouseDown = (textPiece != nil);
 	if (isDoingMouseDown)
 	{
-		[self mouseDownText:theEvent textPiece:textPiece];
+		[self mouseDown:theEvent textPiece:textPiece];
 	}
-	else if (!(theEvent.modifierFlags & NSEventModifierFlagCommand) && self.selectionPieces.count != 0)
+	else if (!(theEvent.modifierFlags & NSEventModifierFlagCommand) && self.isAnySelected)
 	{
 		// click not in text selection. Clear the selection.
-		[self.selectionPieces removeAllObjects];
+		for (OCRDatum *datum in self.datums)
+		{
+			[datum.selectionPieces removeAllObjects];
+		}
 		[self.view setNeedsDisplay:YES];
 	}
 	return isDoingMouseDown;
 }
 
-- (void)mouseDownText:(NSEvent *)theEvent textPiece:(NSObject *)textPiece
+- (void)mouseDown:(NSEvent *)theEvent textPiece:(NSObject *)textPiece
 {
-	NSValue *rangeValue = self.selectionPieces[textPiece];
+	NSInteger i = 0;
+	NSValue *rangeValue = nil;
+	for (;i < self.datums.count; ++i) {
+		OCRDatum *datum = self.datums[i];
+		rangeValue = datum.selectionPieces[textPiece];
+		if (datum.image != nil && rangeValue != nil)
+		{
+			break;
+		}
+	}
 	if (rangeValue != nil && (theEvent.modifierFlags & NSEventModifierFlagControl) != 0) {
-		NSMenu *theMenu = [[NSMenu alloc] initWithTitle:NSLocalizedString(@"Contextual Menu", @"")];
-		[theMenu insertItemWithTitle:NSLocalizedString(@"Copy", @"") action:@selector(copy:) keyEquivalent:@"" atIndex:0];
+		NSMenu *theMenu = [[NSMenu alloc] initWithTitle:@"Contextual Menu"];
+		[theMenu insertItemWithTitle:@"Copy" action:@selector(copy:) keyEquivalent:@"" atIndex:0];
 		[theMenu insertItem:[NSMenuItem separatorItem] atIndex:1];
-		[theMenu insertItemWithTitle:NSLocalizedString(@"Start Speaking", @"") action:@selector(startSpeaking:) keyEquivalent:@"" atIndex:2];
-		[theMenu insertItemWithTitle:NSLocalizedString(@"Stop Speaking", @"") action:@selector(stopSpeaking:) keyEquivalent:@"" atIndex:3];
+		[theMenu insertItemWithTitle:@"Start Speaking" action:@selector(startSpeaking:) keyEquivalent:@"" atIndex:2];
+		[theMenu insertItemWithTitle:@"Stop Speaking" action:@selector(stopSpeaking:) keyEquivalent:@"" atIndex:3];
 		[NSMenu popUpContextMenu:theMenu withEvent:theEvent forView:self.view];
 	} else {
 		[[NSCursor IBeamCursor] set];
 		if (!(theEvent.modifierFlags & NSEventModifierFlagCommand))
 		{
-			[self.selectionPieces removeAllObjects];
+			for (OCRDatum *datum in self.datums)
+			{
+				[datum.selectionPieces removeAllObjects];
+			}
 			[self.view setNeedsDisplay:YES];
 		}
 	}
@@ -325,22 +424,33 @@ static NSSpeechSynthesizer *sSpeechSynthesizer;
 	BOOL isDoingMouseDragged = (textPiece != nil);
 	if (isDoingMouseDragged)
 	{
-		[self mouseDragText:theEvent textPiece:textPiece];
+		[self mouseDrag:theEvent textPiece:textPiece];
 	}
 	return isDoingMouseDragged;
 }
 
-- (void)mouseDragText:(NSEvent *)theEvent textPiece:(NSObject *)textPiece
+- (void)mouseDrag:(NSEvent *)theEvent textPiece:(NSObject *)textPiece
 {
 	NSPoint startPoint = [self.view convertPoint:[theEvent locationInWindow] fromView:nil];
 	self.isDragging = YES;
 	NSMutableDictionary *previousSelection = [NSMutableDictionary dictionary];
 	if (theEvent.modifierFlags & NSEventModifierFlagCommand)
 	{
-		previousSelection = [self.selectionPieces mutableCopy];
+		for (OCRDatum *datum in self.datums)
+		{
+			if (datum.image != nil)
+			{
+				[previousSelection addEntriesFromDictionary:datum.selectionPieces];
+			}
+		}
 	}
-	[self.selectionPieces removeAllObjects];
-	[self.selectionPieces addEntriesFromDictionary:previousSelection];
+	for (OCRDatum *datum in self.datums)
+	{
+		[datum.selectionPieces removeAllObjects];
+	}
+	if (@available(macOS 10.15, *)) {
+		[self addSelectionPiecesFromDictionary:previousSelection];
+	}
 	while ([theEvent type] != NSEventTypeLeftMouseUp)
 	{
 		if ([theEvent type] == NSEventTypeLeftMouseDragged)
@@ -355,25 +465,46 @@ static NSSpeechSynthesizer *sSpeechSynthesizer;
 	self.isDragging = NO;
 }
 
-/// @param downRect - the rectangle in image coordinates from the start mouse position to the current mouse position.
+/// @param downRect - the rectangle in view coordinates from the start mouse position to the current mouse position.
 /// @param previousSelection - the selection as it was before the call to this. This method will update it.
 - (void)updateSelectionFromDownRect:(NSRect)downRect previousSelection:(NSMutableDictionary *)previousSelection
 {
 	if (@available(macOS 10.15, *))
 	{
-		NSMutableDictionary *selectionSet = [NSMutableDictionary dictionary];
-		for (VNRecognizedTextObservation *piece in self.textPieces)
-		{
-			CGRect pieceR = [self boundBoxOfPiece:piece];
-			if (CGRectIntersectsRect(downRect, pieceR)) {
-				NSRange r = [self rangeOfPiece:piece intersectsRect:downRect];
-				selectionSet[piece] = [NSValue valueWithRange:r];
-				previousSelection[piece] = nil;
+		BOOL needsDisplay = NO;
+
+		for (OCRDatum *datum in self.datums) {
+			if (datum.image != nil)
+			{
+				NSMutableDictionary *selectionDict = [NSMutableDictionary dictionary];
+				CGSize imageSize = datum.selectionLayer.bounds.size;
+				for (VNRecognizedTextObservation *piece in datum.textPieces)
+				{
+					CGRect pieceR = VNImageRectForNormalizedRect(piece.boundingBox, imageSize.width, imageSize.height);
+					pieceR = [datum.selectionLayer convertRect:pieceR toLayer:self.view.layer];
+					if (CGRectIntersectsRect(downRect, pieceR)) {
+						CGRect imageDownRect = [datum.selectionLayer convertRect:downRect fromLayer:self.view.layer];
+						CGRect pieceDownRect = VNNormalizedRectForImageRect(imageDownRect, imageSize.width, imageSize.height);
+						NSRange r = [self rangeOfPiece:piece intersectsRect:pieceDownRect];
+						NSValue *rangePtr = previousSelection[piece];
+						if (rangePtr != nil) {
+							NSRange oldRange = [rangePtr rangeValue];
+							r = UnionRanges(r, oldRange);
+							previousSelection[piece] = nil;
+						}
+						selectionDict[piece] = [NSValue valueWithRange:r];
+					}
+				}
+				[selectionDict addEntriesFromDictionary:previousSelection];
+				if (![datum.selectionPieces isEqual:selectionDict]) {
+					datum.selectionPieces = selectionDict;
+					needsDisplay = YES;
+				}
+
 			}
 		}
-		[selectionSet addEntriesFromDictionary:previousSelection];
-		if (![self.selectionPieces isEqual:selectionSet]) {
-			self.selectionPieces = selectionSet;
+		if (needsDisplay)
+		{
 			[self.view setNeedsDisplay:YES];
 			[self.view.window invalidateCursorRectsForView:self.view];
 		}
@@ -383,7 +514,7 @@ static NSSpeechSynthesizer *sSpeechSynthesizer;
 // if the start and end indices delimit a range that intersects r, return the range, else the NotFound range.
 //
 // @param piece - the VNRecognizedTextObservation to examine
-// @param r - The rectangle to intersect against
+// @param r - The rectangle, in VNRecognizedTextObservation coordinates to intersect against
 // @param start - the start index into the string of the text of the piece
 // @param end - the end index into the string of the text of the piece
 // @return the range of the word of the piece that downRect intersects, else the NotFound range.
@@ -401,6 +532,7 @@ static NSSpeechSynthesizer *sSpeechSynthesizer;
 	return NSMakeRange(NSNotFound, 0);
 }
 
+/// @param downRect - in VNRecognizedTextObservation coordinates
 // @return the first range of the word of the piece that downRect intersects, else the NotFound range.
 - (NSRange)firstRangeOfPiece:(VNRecognizedTextObservation *)piece intersectsRect:(NSRect)downRect indexSet:(NSIndexSet *)wordStarts  API_AVAILABLE(macos(10.15))
 {
@@ -418,6 +550,7 @@ static NSSpeechSynthesizer *sSpeechSynthesizer;
 	return NSMakeRange(NSNotFound, 0);
 }
 
+/// @param downRect - in VNRecognizedTextObservation coordinates
 /// @return the last range of the word of the piece that downRect intersects, else the NotFound range.
 - (NSRange)lastRangeOfPiece:(VNRecognizedTextObservation *)piece intersectsRect:(NSRect)downRect indexSet:(NSIndexSet *)wordStarts  API_AVAILABLE(macos(10.15))
 {
@@ -435,6 +568,7 @@ static NSSpeechSynthesizer *sSpeechSynthesizer;
 	return NSMakeRange(0, NSNotFound);
 }
 
+/// @param downRect - in VNRecognizedTextObservation coordinates
 /// @return the range of all of the words of the text of the piece that downRect intersects.
 - (NSRange)rangeOfPiece:(VNRecognizedTextObservation *)piece intersectsRect:(NSRect)downRect API_AVAILABLE(macos(10.15))
 {
@@ -459,15 +593,21 @@ static NSSpeechSynthesizer *sSpeechSynthesizer;
 	}
 	else if (@available(macOS 10.15, *))
 	{
-		if (self.textPieces)
+		for (OCRDatum *datum in self.datums)
 		{
-			CGRect container = [[[self view] enclosingScrollView] documentVisibleRect];
-			for (VNRecognizedTextObservation *piece in self.textPieces)
+			if (datum.image != nil && datum.textPieces.count)
 			{
-				CGRect r = [self boundBoxOfPiece:piece];
-				r = CGRectIntersection(r, container);
-				if (!CGRectIsEmpty(r)) {
-					[self.view addCursorRect:r cursor:[NSCursor IBeamCursor]];
+				CGRect container = [[[self view] enclosingScrollView] documentVisibleRect];
+				CGSize imageSize = datum.selectionLayer.bounds.size;
+				for (VNRecognizedTextObservation *piece in datum.textPieces)
+				{
+					CGRect r = VNImageRectForNormalizedRect(piece.boundingBox, imageSize.width, imageSize.height);
+					r = [datum.selectionLayer convertRect:r toLayer:self.view.layer];
+					r = CGRectIntersection(r, container);
+					if (!CGRectIsEmpty(r))
+					{
+						[self.view addCursorRect:r cursor:[NSCursor IBeamCursor]];
+					}
 				}
 			}
 		}
@@ -481,15 +621,15 @@ static NSSpeechSynthesizer *sSpeechSynthesizer;
 {
 	if ([menuItem action] == @selector(copy:))
 	{
-		BOOL isValid = [self.selectionPieces count] != 0;
-		menuItem.title = isValid ? NSLocalizedString(@"Copy Text", @"") : NSLocalizedString(@"Copy", @"");
-		return isValid;
+		BOOL isAnySelected = self.isAnySelected;
+		menuItem.title = isAnySelected ? NSLocalizedString(@"Copy Text", @"") : NSLocalizedString(@"Copy", @"");
+		return isAnySelected;
 	}
 	else if ([menuItem action] == @selector(selectAll:))
 	{
 		if (@available(macOS 10.15, *))
 		{
-			return [self.textPieces count] != 0 && [self.textPieces count] != [self.selectionPieces count];
+			return self.totalTextPiecesCount != 0 && self.totalTextPiecesCount != self.totalSelectionPiecesCount;
 		} else {
 			return  NO;
 		}
@@ -499,7 +639,7 @@ static NSSpeechSynthesizer *sSpeechSynthesizer;
 	{
 		if (@available(macOS 10.15, *))
 		{
-			return [self.selectionPieces count] != 0;
+			return self.isAnySelected;
 		} else {
 			return  NO;
 		}
@@ -528,14 +668,21 @@ static NSSpeechSynthesizer *sSpeechSynthesizer;
 
 - (void)selectAll:(id)sender
 {
+
 	if (@available(macOS 10.15, *))
 	{
-		self.selectionPieces = [NSMutableDictionary dictionary];
-		for (VNRecognizedTextObservation *piece in self.textPieces)
+		for (OCRDatum *datum in self.datums)
 		{
-			NSArray<VNRecognizedText *> *text1 = [piece topCandidates:1];
-			NSRange r = NSMakeRange(0, text1.firstObject.string.length);
-			self.selectionPieces[piece] = [NSValue valueWithRange:r];
+			if (datum.image != nil)
+			{
+				datum.selectionPieces = [NSMutableDictionary dictionary];
+				for (VNRecognizedTextObservation *piece in datum.textPieces)
+				{
+					NSArray<VNRecognizedText *> *text1 = [piece topCandidates:1];
+					NSRange r = NSMakeRange(0, text1.firstObject.string.length);
+					datum.selectionPieces[piece] = [NSValue valueWithRange:r];
+				}
+			}
 		}
 		[self.view setNeedsDisplay:YES];
 		[self.view.window invalidateCursorRectsForView:self.view];
@@ -559,7 +706,7 @@ static NSSpeechSynthesizer *sSpeechSynthesizer;
 
 - (id)validRequestorForSendType:(NSString *)sendType returnType:(NSString *)returnType
 {
-  if (([sendType isEqual:NSPasteboardTypeString] || [sendType isEqual:NSStringPboardType]) && [self.selectionPieces count] != 0)
+  if (([sendType isEqual:NSPasteboardTypeString] || [sendType isEqual:NSStringPboardType]) && self.isAnySelected)
 	{
     return self;
   }
@@ -568,7 +715,7 @@ static NSSpeechSynthesizer *sSpeechSynthesizer;
 
 - (BOOL)writeSelectionToPasteboard:(NSPasteboard *)pboard types:(NSArray *)types
 {
-  if (([types containsObject:NSPasteboardTypeString] || [types containsObject:NSStringPboardType]) && [self.selectionPieces count] != 0)
+  if (([types containsObject:NSPasteboardTypeString] || [types containsObject:NSStringPboardType]) && self.isAnySelected)
 	{
     [self copyToPasteboard:pboard];
     return YES;

--- a/Classes/Session/OCRVision/OCRTracker.m
+++ b/Classes/Session/OCRVision/OCRTracker.m
@@ -499,7 +499,7 @@ static NSSpeechSynthesizer *sSpeechSynthesizer;
 	{
 		if (@available(macOS 10.15, *))
 		{
-			return [self.textPieces count] != 0;
+			return [self.selectionPieces count] != 0;
 		} else {
 			return  NO;
 		}

--- a/Classes/Session/OCRVision/OCRTracker.m
+++ b/Classes/Session/OCRVision/OCRTracker.m
@@ -1,0 +1,594 @@
+//  OCRTracker.m
+//  MockSimpleComic
+//
+//  Created by David Phillip Oster on 5/21/2022 Apache Version 2 open source license.
+//
+
+#import "OCRTracker.h"
+
+#import "OCRVision.h"
+#import <Vision/Vision.h>
+
+/// @return the quadrilateral of the rect observation as a NSBezierPath/
+API_AVAILABLE(macos(10.15))
+static NSBezierPath *BezierPathFromRectObservation(VNRectangleObservation *piece)
+{
+	NSBezierPath *path = [NSBezierPath bezierPath];
+	[path moveToPoint:piece.topLeft];
+	[path lineToPoint:piece.topRight];
+	[path lineToPoint:piece.bottomRight];
+	[path lineToPoint:piece.bottomLeft];
+	[path closePath];
+	return path;
+}
+
+/// @param piece - the TextObservation
+/// @param r - the range of the string of the TextObservation
+/// @return the quadrilateral of the text observation as a NSBezierPath/
+API_AVAILABLE(macos(10.15))
+static NSBezierPath *BezierPathFromTextObservationRange(VNRecognizedTextObservation *piece, NSRange r)
+{
+	VNRecognizedText *recognizedText = [[piece topCandidates:1] firstObject];
+	// VNRectangleObservation is a superclass of VNRecognizedTextObservation. On error, use the whole thing.
+	VNRectangleObservation *rect = [recognizedText boundingBoxForRange:r error:NULL] ?: piece;
+	return BezierPathFromRectObservation(rect);
+}
+
+
+/// @return the NSRect from two points.
+static NSRect RectFrom2Points(NSPoint a, NSPoint b)
+{
+	return CGRectStandardize(NSMakeRect(a.x, a.y, b.x - a.x, b.y - a.y));
+}
+
+/// @return the set of indices into a string such that s[index] is at the near the beginning or end of a whitespace delimited 'word'
+static NSIndexSet *WordsBoundariesOfString(NSString *s)
+{
+	NSMutableIndexSet *indicies = [NSMutableIndexSet indexSetWithIndex:0];
+	[indicies addIndex:s.length];
+	NSScanner *scanner = [[NSScanner alloc] initWithString:s];
+	NSCharacterSet *textChars = [[NSCharacterSet whitespaceAndNewlineCharacterSet] invertedSet];
+	while ([scanner scanCharactersFromSet:textChars intoString:NULL])
+	{
+		[indicies addIndex:scanner.scanLocation];
+	}
+	return indicies;
+}
+
+/// Given two ranges in order, early before late
+/// @return a continguous range that spans from early to late.
+static NSRange UnionRanges(NSRange early, NSRange late)
+{
+	return NSMakeRange(early.location, late.length+late.location - early.location);
+}
+
+
+static NSSpeechSynthesizer *sSpeechSynthesizer;
+
+@interface OCRTracker()
+@property BOOL isDragging;
+
+/// <VNRecognizedTextObservation *> - 10.15 and newer
+@property NSArray *textPieces;
+
+// Key is VNRecognizedTextObservation.
+// The value is the NSRange of the underlying string to show as selected.
+@property NSMutableDictionary<NSObject *, NSValue *> *selectionPieces;
+
+@property (weak, nullable) NSView *view;
+
+@end
+
+@implementation OCRTracker
+
+- (instancetype)initWithView:(NSView *)view
+{
+	self = [super init];
+	if (self)
+	{
+		_view = view;
+	}
+	return self;
+}
+
+- (void)becomeNextResponder {
+	if (self.view.nextResponder != self)
+	{
+		self.nextResponder = self.view.nextResponder;
+		self.view.nextResponder = self;
+	}
+}
+
+- (BOOL)acceptsFirstResponder
+{
+  return YES;
+}
+
+- (void)drawRect:(NSRect)dirtyRect
+{
+	if (self.textPieces == nil)
+	{
+		if (@available(macOS 10.15, *))
+		{
+			// temporary, to show we haven't run the OCR yet.
+			[[NSColor.yellowColor colorWithAlphaComponent:0.4] set];
+			CGRect smallBounds = CGRectInset(self.view.bounds, 20, 20);
+			NSRectFill(smallBounds);
+		}
+	} else {
+		if (@available(macOS 10.15, *))
+		{
+			NSAffineTransform *transform = [NSAffineTransform transform];
+			[transform scaleXBy:self.view.bounds.size.width yBy:self.view.bounds.size.height];
+			for (VNRecognizedTextObservation *piece in self.textPieces)
+			{
+				NSValue *rangeValue = self.selectionPieces[piece];
+				if (rangeValue != nil)
+				{
+					NSBezierPath *path = BezierPathFromTextObservationRange(piece, rangeValue.rangeValue);
+					[path transformUsingAffineTransform:transform];
+					[[NSColor.yellowColor colorWithAlphaComponent:0.4] set];
+					[path fill];
+				}
+			}
+		}
+	}
+}
+
+#pragma mark Model
+
+- (NSString *)allText
+{
+	if (@available(macOS 10.15, *))
+	{
+		NSMutableArray *a = [NSMutableArray array];
+		for (VNRecognizedTextObservation *piece in self.textPieces)
+		{
+			NSArray<VNRecognizedText *> *text1 = [piece topCandidates:1];
+			[a addObject:text1.firstObject.string];
+		}
+		return [a componentsJoinedByString:@"\n"];
+	}
+	return nil;
+}
+
+- (NSString *)selection
+{
+	NSMutableArray *a = [NSMutableArray array];
+	if (@available(macOS 10.15, *))
+	{
+		for (VNRecognizedTextObservation *piece in self.textPieces)
+		{
+			NSValue *rangeInAValue = self.selectionPieces[piece];
+			if (rangeInAValue != nil)
+			{
+				NSArray<VNRecognizedText *> *text1 = [piece topCandidates:1];
+				NSString *s = text1.firstObject.string;
+				s = [s substringWithRange:[rangeInAValue rangeValue]];
+				[a addObject:s];
+			}
+		}
+	}
+	return [a componentsJoinedByString:@"\n"];
+}
+
+- (nullable VNRecognizedTextObservation *)textPieceForMouseEvent:(NSEvent *)theEvent API_AVAILABLE(macos(10.15))
+{
+	NSPoint where = [self.view convertPoint:[theEvent locationInWindow] fromView:nil];
+	return [self textPieceForPoint:where];
+}
+
+/// For a point, find the textPiece
+///
+/// @param where - a point in View coordinates,
+/// @return the textPiece that contains that point
+- (nullable VNRecognizedTextObservation *)textPieceForPoint:(CGPoint)where API_AVAILABLE(macos(10.15))
+{
+	if (@available(macOS 10.15, *))
+	{
+		if (self.textPieces)
+		{
+			CGRect container = [[[self view] enclosingScrollView] documentVisibleRect];
+			for (VNRecognizedTextObservation *piece in self.textPieces)
+			{
+				CGRect r = [self boundBoxOfPiece:piece];
+				r = CGRectIntersection(r, container);
+				if (!CGRectIsEmpty(r) && CGRectContainsPoint(r, where)) {
+					return piece;
+				}
+			}
+		}
+	}
+	return nil;
+}
+
+/// Return the boundbox of a piece in View coordinates
+///
+/// @param piece - A text piece
+/// @return The bound box in View coordinates
+- (CGRect)boundBoxOfPiece:(VNRecognizedTextObservation *)piece API_AVAILABLE(macos(10.15))
+{
+	NSAffineTransform *transform = [NSAffineTransform transform];
+	[transform scaleXBy:self.view.bounds.size.width yBy:self.view.bounds.size.height];
+	CGRect r = piece.boundingBox;
+	r.origin = [transform transformPoint:r.origin];
+	r.size = [transform transformSize:r.size];
+	return r;
+}
+
+/// Return the boundbox of a range of a piece in View coordinates
+///
+/// @param piece - A text piece
+/// @param charRange - the range within the piece.
+/// @return The bound box in View coordinates
+- (CGRect)boundBoxOfPiece:(VNRecognizedTextObservation *)piece range:(NSRange)charRange API_AVAILABLE(macos(10.15))
+{
+	VNRecognizedText *text1 = [[piece topCandidates:1] firstObject];
+	NSString *s1 = text1.string;
+	if (s1.length < charRange.location + charRange.length)
+	{
+		return CGRectNull;
+	}
+
+	NSAffineTransform *transform = [NSAffineTransform transform];
+	[transform scaleXBy:self.view.bounds.size.width yBy:self.view.bounds.size.height];
+	NSBezierPath *path = BezierPathFromTextObservationRange(piece, charRange);
+	CGRect r = path.bounds;
+	r.origin = [transform transformPoint:r.origin];
+	r.size = [transform transformSize:r.size];
+	return r;
+}
+
+
+#pragma mark OCR
+
+/// Housekeeping around being called by the OCR engine.
+///
+///  Since this will affect the U.I., sets state on the main thread.
+/// @param results -  the OCR's results object.
+- (void)ocrDidFinish:(id<OCRVisionResults>)results
+{
+	NSArray *textPieces = @[];
+	if (@available(macOS 10.15, *)) {
+		textPieces = results.textObservations;
+	}
+	// Since we are changing state that affects the U.I., we do it on the main thread in the future,
+	// but `complete` isn't guaranteed to exist then, so we assign to locals so it will be captured
+	// by the block.
+	dispatch_async(dispatch_get_main_queue(), ^{
+		self.textPieces = textPieces;
+		[self.selectionPieces removeAllObjects];
+		[self.view setNeedsDisplay:YES];
+		[self.view.window invalidateCursorRectsForView:self.view];
+	});
+}
+
+- (void)ocrImage:(NSImage *)image
+{
+	if (@available(macOS 10.15, *)) {
+		__block OCRVision *ocrVision = [[OCRVision alloc] init];
+		dispatch_async(dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0), ^{
+			[ocrVision ocrImage:image completion:^(id<OCRVisionResults> _Nonnull complete) {
+				[self ocrDidFinish:complete];
+				ocrVision = nil;
+			}];
+		});
+	}
+}
+
+- (void)ocrCGImage:(CGImageRef)cgImage
+{
+	if (@available(macOS 10.15, *)) {
+		__block OCRVision *ocrVision = [[OCRVision alloc] init];
+		dispatch_async(dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0), ^{
+			[ocrVision ocrCGImage:cgImage completion:^(id<OCRVisionResults> _Nonnull complete) {
+				[self ocrDidFinish:complete];
+				ocrVision = nil;
+			}];
+		});
+	}
+}
+
+
+#pragma mark Mouse
+
+- (BOOL)didMouseDown:(NSEvent *)theEvent
+{
+	NSObject *textPiece = nil;
+	if (@available(macOS 10.15, *)) {
+		textPiece = [self textPieceForMouseEvent:theEvent];
+	}
+	BOOL isDoingMouseDown = (textPiece != nil);
+	if (isDoingMouseDown)
+	{
+		[self mouseDownText:theEvent textPiece:textPiece];
+	}
+	else if (!(theEvent.modifierFlags & NSEventModifierFlagCommand) && self.selectionPieces.count != 0)
+	{
+		// click not in text selection. Clear the selection.
+		[self.selectionPieces removeAllObjects];
+		[self.view setNeedsDisplay:YES];
+	}
+	return isDoingMouseDown;
+}
+
+- (void)mouseDownText:(NSEvent *)theEvent textPiece:(NSObject *)textPiece
+{
+	NSValue *rangeValue = self.selectionPieces[textPiece];
+	if (rangeValue != nil && (theEvent.modifierFlags & NSEventModifierFlagControl) != 0) {
+		NSMenu *theMenu = [[NSMenu alloc] initWithTitle:@"Contextual Menu"];
+		[theMenu insertItemWithTitle:@"Copy" action:@selector(copy:) keyEquivalent:@"" atIndex:0];
+		[theMenu insertItem:[NSMenuItem separatorItem] atIndex:1];
+		[theMenu insertItemWithTitle:@"Start Speaking" action:@selector(startSpeaking:) keyEquivalent:@"" atIndex:2];
+		[theMenu insertItemWithTitle:@"Stop Speaking" action:@selector(stopSpeaking:) keyEquivalent:@"" atIndex:3];
+		[NSMenu popUpContextMenu:theMenu withEvent:theEvent forView:self.view];
+	} else {
+		[[NSCursor IBeamCursor] set];
+		if (!(theEvent.modifierFlags & NSEventModifierFlagCommand))
+		{
+			[self.selectionPieces removeAllObjects];
+			[self.view setNeedsDisplay:YES];
+		}
+	}
+}
+
+- (BOOL)didMouseDragged:(NSEvent *)theEvent
+{
+	NSObject *textPiece = nil;
+	if (@available(macOS 10.15, *)) {
+		textPiece = [self textPieceForMouseEvent:theEvent];
+	}
+	BOOL isDoingMouseDragged = (textPiece != nil);
+	if (isDoingMouseDragged)
+	{
+		[self mouseDragText:theEvent textPiece:textPiece];
+	}
+	return isDoingMouseDragged;
+}
+
+- (void)mouseDragText:(NSEvent *)theEvent textPiece:(NSObject *)textPiece
+{
+	NSPoint startPoint = [self.view convertPoint:[theEvent locationInWindow] fromView:nil];
+	self.isDragging = YES;
+	NSMutableDictionary *previousSelection = [NSMutableDictionary dictionary];
+	if (theEvent.modifierFlags & NSEventModifierFlagCommand)
+	{
+		previousSelection = [self.selectionPieces mutableCopy];
+	}
+	[self.selectionPieces removeAllObjects];
+	[self.selectionPieces addEntriesFromDictionary:previousSelection];
+	while ([theEvent type] != NSEventTypeLeftMouseUp)
+	{
+		if ([theEvent type] == NSEventTypeLeftMouseDragged)
+		{
+			NSPoint endPoint = [self.view convertPoint:[theEvent locationInWindow] fromView:nil];
+			NSRect downRect = RectFrom2Points(startPoint, endPoint);
+			[self updateSelectionFromDownRect:downRect previousSelection:previousSelection];
+		}
+		theEvent = [[self.view window] nextEventMatchingMask: NSEventMaskLeftMouseUp | NSEventMaskLeftMouseDragged];
+	}
+	[self.view.window invalidateCursorRectsForView:self.view];
+	self.isDragging = NO;
+}
+
+/// @param downRect - the rectangle in image coordinates from the start mouse position to the current mouse position.
+/// @param previousSelection - the selection as it was before the call to this. This method will update it.
+- (void)updateSelectionFromDownRect:(NSRect)downRect previousSelection:(NSMutableDictionary *)previousSelection
+{
+	if (@available(macOS 10.15, *))
+	{
+		NSMutableDictionary *selectionSet = [NSMutableDictionary dictionary];
+		for (VNRecognizedTextObservation *piece in self.textPieces)
+		{
+			CGRect pieceR = [self boundBoxOfPiece:piece];
+			if (CGRectIntersectsRect(downRect, pieceR)) {
+				NSRange r = [self rangeOfPiece:piece intersectsRect:downRect];
+				selectionSet[piece] = [NSValue valueWithRange:r];
+				previousSelection[piece] = nil;
+			}
+		}
+		[selectionSet addEntriesFromDictionary:previousSelection];
+		if (![self.selectionPieces isEqual:selectionSet]) {
+			self.selectionPieces = selectionSet;
+			[self.view setNeedsDisplay:YES];
+			[self.view.window invalidateCursorRectsForView:self.view];
+		}
+	}
+}
+
+// if the start and end indices delimit a range that intersects r, return the range, else the NotFound range.
+//
+// @param piece - the VNRecognizedTextObservation to examine
+// @param r - The rectangle to intersect against
+// @param start - the start index into the string of the text of the piece
+// @param end - the end index into the string of the text of the piece
+// @return the range of the word of the piece that downRect intersects, else the NotFound range.
+- (NSRange)rangeOfPiece:(VNRecognizedTextObservation *)piece intersectsRect:(NSRect)r start:(NSUInteger)start end:(NSUInteger)end  API_AVAILABLE(macos(10.15))
+{
+	if (0 < end - start)	// ignore zero length ranges.
+	{
+		NSRange wordRange = NSMakeRange(start, end - start);
+		CGRect wordR = [self boundBoxOfPiece:piece range:wordRange];
+		if (CGRectIntersectsRect(r, wordR))
+		{
+			return wordRange;
+		}
+	}
+	return NSMakeRange(NSNotFound, 0);
+}
+
+// @return the first range of the word of the piece that downRect intersects, else the NotFound range.
+- (NSRange)firstRangeOfPiece:(VNRecognizedTextObservation *)piece intersectsRect:(NSRect)downRect indexSet:(NSIndexSet *)wordStarts  API_AVAILABLE(macos(10.15))
+{
+	NSUInteger endIndex = [wordStarts indexGreaterThanIndex:0];
+	NSUInteger startIndex = 0;
+	for (;endIndex != NSNotFound; endIndex = [wordStarts indexGreaterThanIndex:endIndex])
+	{
+		NSRange wordRange = [self rangeOfPiece:piece intersectsRect:downRect start:startIndex end:endIndex];
+		if (wordRange.location != NSNotFound)
+		{
+			return wordRange;
+		}
+		startIndex = endIndex;
+	}
+	return NSMakeRange(NSNotFound, 0);
+}
+
+/// @return the last range of the word of the piece that downRect intersects, else the NotFound range.
+- (NSRange)lastRangeOfPiece:(VNRecognizedTextObservation *)piece intersectsRect:(NSRect)downRect indexSet:(NSIndexSet *)wordStarts  API_AVAILABLE(macos(10.15))
+{
+	NSUInteger endIndex = [wordStarts lastIndex];
+	NSUInteger startIndex = [wordStarts indexLessThanIndex:endIndex];
+	for (;startIndex != NSNotFound; startIndex = [wordStarts indexLessThanIndex:startIndex])
+	{
+		NSRange wordRange = [self rangeOfPiece:piece intersectsRect:downRect start:startIndex end:endIndex];
+		if (wordRange.location != NSNotFound)
+		{
+			return wordRange;
+		}
+		endIndex = startIndex;
+	}
+	return NSMakeRange(0, NSNotFound);
+}
+
+/// @return the range of all of the words of the text of the piece that downRect intersects.
+- (NSRange)rangeOfPiece:(VNRecognizedTextObservation *)piece intersectsRect:(NSRect)downRect API_AVAILABLE(macos(10.15))
+{
+	VNRecognizedText *text1 = [[piece topCandidates:1] firstObject];
+	NSString *s = text1.string;
+	NSIndexSet *wordStarts = WordsBoundariesOfString(s);
+
+	NSRange first = [self firstRangeOfPiece:piece intersectsRect:downRect indexSet:wordStarts];
+	NSRange last = [self lastRangeOfPiece:piece intersectsRect:downRect indexSet:wordStarts];
+	if (first.location == NSNotFound || last.location == NSNotFound)
+	{
+		return NSMakeRange(0, s.length);
+	}
+	return UnionRanges(first, last);
+}
+
+- (BOOL)didResetCursorRects
+{
+	if (self.isDragging) {
+		[self.view addCursorRect: [[[self view] enclosingScrollView] documentVisibleRect] cursor:[NSCursor IBeamCursor]];
+		return YES;
+	}
+	else if (@available(macOS 10.15, *))
+	{
+		if (self.textPieces)
+		{
+			CGRect container = [[[self view] enclosingScrollView] documentVisibleRect];
+			for (VNRecognizedTextObservation *piece in self.textPieces)
+			{
+				CGRect r = [self boundBoxOfPiece:piece];
+				r = CGRectIntersection(r, container);
+				if (!CGRectIsEmpty(r)) {
+					[self.view addCursorRect:r cursor:[NSCursor IBeamCursor]];
+				}
+			}
+		}
+	}
+	return NO;
+}
+
+#pragma mark Menubar
+
+- (BOOL)validateMenuItem:(NSMenuItem *)menuItem
+{
+	if ([menuItem action] == @selector(copy:))
+	{
+		BOOL isValid = [self.selectionPieces count] != 0;
+		menuItem.title = isValid ? @"Copy Text" : @"Copy";
+		return isValid;
+	}
+	else if ([menuItem action] == @selector(selectAll:))
+	{
+		if (@available(macOS 10.15, *))
+		{
+			return [self.textPieces count] != 0 && [self.textPieces count] != [self.selectionPieces count];
+		} else {
+			return  NO;
+		}
+		return YES;
+	}
+	else if ([menuItem action] == @selector(startSpeaking:))
+	{
+		if (@available(macOS 10.15, *))
+		{
+			return [self.textPieces count] != 0;
+		} else {
+			return  NO;
+		}
+		return YES;
+	}
+	else if ([menuItem action] == @selector(stopSpeaking:))
+	{
+		return [sSpeechSynthesizer isSpeaking];
+	}
+	return NO;
+}
+
+- (void)startSpeaking:(id)sender
+{
+	if (sSpeechSynthesizer == nil)
+	{
+		sSpeechSynthesizer = [[NSSpeechSynthesizer alloc] init];
+	}
+	[sSpeechSynthesizer startSpeakingString:[self selection]];
+}
+
+- (void)stopSpeaking:(id)sender
+{
+	[sSpeechSynthesizer stopSpeaking];
+}
+
+- (void)selectAll:(id)sender
+{
+	if (@available(macOS 10.15, *))
+	{
+		for (VNRecognizedTextObservation *piece in self.textPieces)
+		{
+			NSArray<VNRecognizedText *> *text1 = [piece topCandidates:1];
+			NSRange r = NSMakeRange(0, text1.firstObject.string.length);
+			self.selectionPieces[piece] = [NSValue valueWithRange:r];
+		}
+		[self.view setNeedsDisplay:YES];
+		[self.view.window invalidateCursorRectsForView:self.view];
+	}
+}
+
+- (void)copy:(id)sender
+{
+  NSPasteboard *pboard = [NSPasteboard generalPasteboard];
+  [self copyToPasteboard:pboard];
+}
+
+- (void)copyToPasteboard:(NSPasteboard *)pboard
+{
+  NSString *s = [self selection];
+  [pboard clearContents];
+  [pboard setString:s forType:NSPasteboardTypeString];
+}
+
+#pragma mark Services
+
+- (id)validRequestorForSendType:(NSString *)sendType returnType:(NSString *)returnType
+{
+  if (([sendType isEqual:NSPasteboardTypeString] || [sendType isEqual:NSStringPboardType]) && [self.selectionPieces count] != 0)
+	{
+    return self;
+  }
+  return [[self nextResponder] validRequestorForSendType:sendType returnType:returnType];
+}
+
+- (BOOL)writeSelectionToPasteboard:(NSPasteboard *)pboard types:(NSArray *)types
+{
+  if (([types containsObject:NSPasteboardTypeString] || [types containsObject:NSStringPboardType]) && [self.selectionPieces count] != 0)
+	{
+    [self copyToPasteboard:pboard];
+    return YES;
+  }
+  return NO;
+}
+
+@end

--- a/Classes/Session/OCRVision/OCRVision.h
+++ b/Classes/Session/OCRVision/OCRVision.h
@@ -1,6 +1,6 @@
 //  OCRVision.h
 //
-//  Created by David Phillip Oster on 5/19/2022
+//  Created by David Phillip Oster on 5/19/2022 Apache Version 2 open source license.
 //
 
 #import <Cocoa/Cocoa.h>

--- a/Classes/Session/OCRVision/OCRVision.h
+++ b/Classes/Session/OCRVision/OCRVision.h
@@ -1,0 +1,63 @@
+//  OCRVision.h
+//
+//  Created by David Phillip Oster on 5/19/2022
+//
+
+#import <Cocoa/Cocoa.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+// OCRedTextView use this NSError Domain
+extern NSErrorDomain const OCRVisionDomain;
+
+enum {
+	OCRVisionErrUnrecognized = 1,
+	OCRVisionErrNoCreate
+};
+
+@class VNRecognizedTextObservation;
+
+/// When the  OCR is complete, it will pass your continuation block an object that responds to this protocol.
+@protocol OCRVisionResults <NSObject>
+
+/// all the text on the page.
+@property(readonly) NSString *allText;
+
+/// non-nil if an error occurred OCR'ing the image.
+@property(readonly, nullable) NSError *ocrError;
+
+/// Once an OCR operation completes, the individual lines of text.
+@property(readonly) NSArray<VNRecognizedTextObservation *> *textObservations;
+
+@end
+
+/// Wrap up the Vision OCR framework in a  simple API
+API_AVAILABLE(macos(10.15))
+@interface OCRVision : NSObject
+
+/// The list of languages the VisionFramework will accept. en_US is the default. Empty array means the VisionFramework is not available.
+@property(class, readonly) NSArray<NSString *> *ocrLanguages;
+
+/// The language the VisionFramework will use. getting nil means the VisionFramework is not available. setting nil restores default.
+@property(class, nullable, setter=setOCRLanguage:) NSString *ocrLanguage;
+
+
+/// Run the ocr engine on the image in the default language. When it's done, call the completion passing an object that implements the OCRVisionResults protocol
+///
+///  Note: does its work on a background concurrent GCD queue. Completion is called on that queue.
+///
+/// @param image - the image to OCR
+/// @param completion - a block passed an object that corresponds to the OCRVision protocol.
+- (void)ocrImage:(NSImage *)image completion:(void (^)(id<OCRVisionResults> _Nonnull ocrResults))completion;
+
+/// Run the ocr engine on the image in the default language. When it's done, call the completion passing an object that implements the OCRVisionResults protocol
+///
+///  Note: does its work on a background concurrent GCD queue. Completion is called on that queue.
+///
+/// @param cgImage - the image to OCR
+/// @param completion - a block passed an object that corresponds to the OCRVision protocol.
+- (void)ocrCGImage:(CGImageRef)cgImage completion:(void (^)(id<OCRVisionResults> _Nonnull ocrResults))completion;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Classes/Session/OCRVision/OCRVision.m
+++ b/Classes/Session/OCRVision/OCRVision.m
@@ -1,6 +1,6 @@
 //  OCRVision.h
 //
-//  Created by David Phillip Oster on 5/19/2022.
+//  Created by David Phillip Oster on 5/19/2022. Apache Version 2 open source license.
 //
 
 #import "OCRVision.h"

--- a/Classes/Session/OCRVision/OCRVision.m
+++ b/Classes/Session/OCRVision/OCRVision.m
@@ -1,0 +1,187 @@
+//  OCRVision.h
+//
+//  Created by David Phillip Oster on 5/19/2022.
+//
+
+#import "OCRVision.h"
+
+#import <Vision/Vision.h>
+
+static NSString *sOCRLanguage;
+
+static NSArray<NSString *> *sOCRLanguages;
+
+// ocrErrors use this NSError Domain
+NSErrorDomain const OCRVisionDomain = @"OCRVisionDomain";
+
+/// Rather than allocate a new object to pass the results, just make the OCRVision object do double duty.
+@interface OCRVision()<OCRVisionResults>
+@property(readwrite) NSArray<VNRecognizedTextObservation *> *textObservations;
+@property(readwrite, nullable, setter=setOCRError:) NSError *ocrError;
+@end
+
+@implementation OCRVision
+
++ (void)initialize
+{
+	[super initialize];
+	static dispatch_once_t onceToken;
+	dispatch_once(&onceToken, ^{
+		NSUInteger revision = VNRecognizeTextRequestRevision1;
+		if (@available(macOS 11.0, *))
+		{
+			revision = VNRecognizeTextRequestRevision2;
+		}
+		if (@available(macOS 12.0, *))
+		{
+			VNRecognizeTextRequest *textRequest = [[VNRecognizeTextRequest alloc] initWithCompletionHandler:^(VNRequest *request, NSError *error){}];
+			sOCRLanguages = [textRequest supportedRecognitionLanguagesAndReturnError:nil];
+		} else {
+			sOCRLanguages = [VNRecognizeTextRequest supportedRecognitionLanguagesForTextRecognitionLevel:VNRequestTextRecognitionLevelAccurate revision:revision error:NULL];
+		}
+		sOCRLanguage = sOCRLanguages.firstObject;
+	});
+}
+
++ (NSArray<NSString *> *)ocrLanguages
+{
+	if (nil == sOCRLanguages){ return @[]; }
+	return sOCRLanguages;
+}
+
++ (NSString *)ocrLanguage
+{
+	return sOCRLanguage;
+}
+
++ (void)setOCRLanguage:(NSString *)ocrLanguage
+{
+	if (nil != ocrLanguage)
+	{
+		if ([[self ocrLanguages] containsObject:ocrLanguage])
+		{
+			sOCRLanguage = ocrLanguage;
+		}
+	} else {
+		sOCRLanguage = sOCRLanguages.firstObject;
+	}
+}
+
+#pragma mark OCR
+
+- (void)callCompletion:(void (^)(id<OCRVisionResults> _Nonnull))completion
+					observations:(NSArray<VNRecognizedTextObservation *> *)observations
+								 error:(NSError *)error
+{
+	self.textObservations = observations;
+	self.ocrError = error;
+	completion(self);
+	self.textObservations = @[];
+	self.ocrError = nil;
+}
+
+- (NSString *)allText
+{
+	NSMutableArray *a = [NSMutableArray array];
+	for (VNRecognizedTextObservation *piece in self.textObservations)
+	{
+		NSArray<VNRecognizedText *> *text1 = [piece topCandidates:1];
+		[a addObject:text1.firstObject.string];
+	}
+	return [a componentsJoinedByString:@"\n"];
+}
+
+
+/// Called by VNRecognizeTextRequest to process the result.
+/// Filter the textObservations that includes actual text, and store in self.textObservations.
+///
+///  Since this is called on a worker queue, it delivers results on the main queue.
+///
+/// @param request - The VNRecognizeTextRequest
+/// @param error - if non-nil, the VNRecognizeTextRequest is reporting an error.
+- (void)handleTextRequest:(nullable VNRequest *)request
+							 completion:(void (^)(id<OCRVisionResults> _Nonnull))completion
+										error:(nullable NSError *)error
+{
+	if (error)
+	{
+		[self callCompletion:completion observations:@[] error:error];
+	}
+	else if ([request isKindOfClass:[VNRecognizeTextRequest class]])
+	{
+		VNRecognizeTextRequest *textRequests = (VNRecognizeTextRequest *)request;
+		NSMutableArray<VNRecognizedTextObservation *> *pieces = [NSMutableArray array];
+		NSArray *results = textRequests.results;
+		for (id rawResult in results)
+		{
+			if ([rawResult isKindOfClass:[VNRecognizedTextObservation class]])
+			{
+				VNRecognizedTextObservation *textO = (VNRecognizedTextObservation *)rawResult;
+				NSArray<VNRecognizedText *> *text1 = [textO topCandidates:1];
+				if (text1.count)
+				{
+					[pieces addObject:textO];
+				}
+			}
+		}
+		[self callCompletion:completion observations:pieces error:nil];
+	} else {
+		NSString *desc = @"Unrecognized text request";
+		NSError *err = [NSError errorWithDomain:@""
+																			 code:OCRVisionErrUnrecognized
+																	 userInfo:@{NSLocalizedDescriptionKey : desc}];
+		[self callCompletion:completion observations:@[] error:err];
+	}
+}
+
+- (void)ocrCGImage:(CGImageRef)cgImage completion:(void (^)(id<OCRVisionResults> _Nonnull))completion
+{
+  __weak typeof(self) weakSelf = self;
+  VNRecognizeTextRequest *textRequest =
+      [[VNRecognizeTextRequest alloc] initWithCompletionHandler:^(VNRequest *request, NSError *error)
+			{
+				[weakSelf handleTextRequest:request completion:completion error:error];
+			}];
+  if (textRequest)
+  {
+		NSString *ocrLanguage = [[self class] ocrLanguage];
+		if (ocrLanguage)
+		{
+			textRequest.recognitionLanguages = @[ocrLanguage];
+			textRequest.usesLanguageCorrection = YES;
+		}
+		NSError *error = nil;
+    VNImageRequestHandler *handler = [[VNImageRequestHandler alloc] initWithCGImage:cgImage options:@{}];
+		if (![handler performRequests:@[textRequest] error:&error])
+		{
+			[self callCompletion:completion observations:@[] error:error];
+		}
+  } else {
+		NSString *desc = @"Could not create text request";
+		NSError *err = [NSError errorWithDomain:OCRVisionDomain
+																			 code:OCRVisionErrNoCreate
+																	 userInfo:@{NSLocalizedDescriptionKey : desc}];
+			[self callCompletion:completion observations:@[] error:err];
+  }
+}
+
+- (void)ocrImage:(NSImage *)image completion:(void (^)(id<OCRVisionResults> _Nonnull))completion
+{
+	NSData *imageData = image.TIFFRepresentation;
+	if(imageData != nil)
+	{
+		CGImageSourceRef imageSource = CGImageSourceCreateWithData((__bridge CFDataRef)imageData, NULL);
+		if (imageSource != nil)
+		{
+			CGImageRef imageRef =  CGImageSourceCreateImageAtIndex(imageSource, 0, NULL);
+			if (imageRef != nil)
+			{
+				[self ocrCGImage:imageRef completion:completion];
+				CFRelease(imageRef);
+			}
+			CFRelease(imageSource);
+		}
+	}
+}
+
+@end

--- a/Classes/Session/TSSTPageView.m
+++ b/Classes/Session/TSSTPageView.m
@@ -19,6 +19,8 @@
 
 #include <tgmath.h>
 #import "TSSTPageView.h"
+
+#import "OCRTracker.h"
 #import "TSSTImageUtilities.h"
 #import "SimpleComicAppDelegate.h"
 #import "TSSTSessionWindowController.h"

--- a/Classes/Session/TSSTPageView.m
+++ b/Classes/Session/TSSTPageView.m
@@ -73,7 +73,7 @@ typedef struct {
 	/*! This is the rect describing the users page selection. */
 	NSRect cropRect;
 		/*! handles mouse tracking of the OCR'ed text */
-	OCRTracker *tracker;
+	OCRTracker *ocrTracker;
 }
 @synthesize imageBounds;
 @synthesize rotation;
@@ -104,7 +104,7 @@ typedef struct {
 		scrollTimer = nil;
 		acceptingDrag = NO;
 		pageSelection = -1;
-		tracker = [[OCRTracker alloc] initWithView:self];
+		ocrTracker = [[OCRTracker alloc] initWithView:self];
 		self.acceptsTouchEvents = YES;
 	}
 	return self;
@@ -124,7 +124,7 @@ typedef struct {
 
 - (BOOL)becomeFirstResponder
 {
-	[tracker becomeNextResponder];
+	[ocrTracker becomeNextResponder];
   return YES;
 }
 
@@ -136,9 +136,9 @@ typedef struct {
 		firstPageImage = first;
 		if([self didStartAnimationForImage: firstPageImage])
 		{
-			[tracker ocrImage:nil];
+			[ocrTracker ocrImage:nil];
 		} else {
-			[tracker ocrImage:firstPageImage];
+			[ocrTracker ocrImage:firstPageImage];
 		}
 	}
 	
@@ -147,9 +147,9 @@ typedef struct {
 		secondPageImage = second;
 		if([self didStartAnimationForImage: secondPageImage])
 		{
-			[tracker ocrImage2:nil];
+			[ocrTracker ocrImage2:nil];
 		} else {
-			[tracker ocrImage2:secondPageImage];
+			[ocrTracker ocrImage2:secondPageImage];
 		}
 	}
 	
@@ -354,7 +354,7 @@ typedef struct {
 		[firstPageLayer setFrame:frame];
 		[newLayer addSublayer:firstPageLayer];
 		CFRelease(firstPageImageRef);
-		CALayer *selectionLayer = [tracker layerForImage:firstPageImage imageLayer:firstPageLayer];
+		CALayer *selectionLayer = [ocrTracker layerForImage:firstPageImage imageLayer:firstPageLayer];
 		if (selectionLayer) {
 			[firstPageLayer addSublayer:selectionLayer];
 		}
@@ -381,7 +381,7 @@ typedef struct {
 			[secondPageLayer setFrame:frame];
 			[newLayer addSublayer:secondPageLayer];
 			CFRelease(secondPageImageRef);
-			CALayer *selectionLayer = [tracker layerForImage:secondPageImage imageLayer:secondPageLayer];
+			CALayer *selectionLayer = [ocrTracker layerForImage:secondPageImage imageLayer:secondPageLayer];
 			if (selectionLayer) {
 				[secondPageLayer addSublayer:selectionLayer];
 			}
@@ -1337,7 +1337,7 @@ typedef struct {
 		NSPoint cursor = [self convertPoint: [theEvent locationInWindow] fromView: nil];
 		cropRect.origin = cursor;
 	}
-	else if([tracker didMouseDown:theEvent])
+	else if([ocrTracker didMouseDown:theEvent])
 	{
 		/* done */
 	}
@@ -1394,7 +1394,7 @@ typedef struct {
 		}
 		[self setNeedsDisplay: YES];
 	}
-	else if([tracker didMouseDragged:theEvent])
+	else if([ocrTracker didMouseDragged:theEvent])
 	{
 		/* done */
 	}
@@ -1546,7 +1546,7 @@ typedef struct {
 
 - (void)resetCursorRects
 {
-	if([tracker didResetCursorRects])
+	if([ocrTracker didResetCursorRects])
 	{
 		/* done */
 	}

--- a/Classes/Session/TSSTPageView.m
+++ b/Classes/Session/TSSTPageView.m
@@ -1330,6 +1330,10 @@ typedef struct {
 		NSPoint cursor = [self convertPoint: [theEvent locationInWindow] fromView: nil];
 		cropRect.origin = cursor;
 	}
+	else if([tracker didMouseDown:theEvent])
+	{
+		/* done */
+	}
 	else if([self dragIsPossible])
 	{
 		[[NSCursor closedHandCursor] set];
@@ -1382,6 +1386,10 @@ typedef struct {
 			pageSelection = 1;
 		}
 		[self setNeedsDisplay: YES];
+	}
+	else if([tracker didMouseDragged:theEvent])
+	{
+		/* done */
 	}
 	else if([self dragIsPossible])
 	{
@@ -1531,7 +1539,11 @@ typedef struct {
 
 - (void)resetCursorRects
 {
-	if([self dragIsPossible])
+	if([tracker didResetCursorRects])
+	{
+		/* done */
+	}
+	else if([self dragIsPossible])
 	{
 		NSCursor *cursor = isInDrag ? [NSCursor closedHandCursor] : [NSCursor openHandCursor];
 		[self addCursorRect: [[self enclosingScrollView] documentVisibleRect] cursor: cursor];

--- a/Classes/Session/TSSTPageView.m
+++ b/Classes/Session/TSSTPageView.m
@@ -61,6 +61,9 @@ typedef struct {
 	
 	//! This controls the drawing of the accepting drag-drop border highlighting
 	BOOL acceptingDrag;
+
+	/// YES while we are actively dragging
+	BOOL isInDrag;
 	
 	/*!	While page selection is in progress this method has a value of 1 or 2.
 	 The selection number coresponds to a highlighted page. */
@@ -1352,6 +1355,7 @@ typedef struct {
 	}
 	else if([self dragIsPossible])
 	{
+		isInDrag = YES;
 		while ([theEvent type] != NSEventTypeLeftMouseUp)
 		{
 			if ([theEvent type] == NSEventTypeLeftMouseDragged)
@@ -1362,6 +1366,7 @@ typedef struct {
 			}
 			theEvent = [[self window] nextEventMatchingMask: NSEventMaskLeftMouseUp | NSEventMaskLeftMouseDragged];
 		}
+		isInDrag = NO;
 		[[self window] invalidateCursorRectsForView: self];
 	}
 }
@@ -1498,7 +1503,8 @@ typedef struct {
 {
 	if([self dragIsPossible])
 	{
-		[self addCursorRect: [[self enclosingScrollView] documentVisibleRect] cursor: [NSCursor openHandCursor]];
+		NSCursor *cursor = isInDrag ? [NSCursor closedHandCursor] : [NSCursor openHandCursor];
+		[self addCursorRect: [[self enclosingScrollView] documentVisibleRect] cursor: cursor];
 	}
 //	else if(canCrop)
 //	{

--- a/Classes/Session/TSSTPageView.m
+++ b/Classes/Session/TSSTPageView.m
@@ -134,8 +134,10 @@ typedef struct {
 	if(first != firstPageImage)
 	{
 		firstPageImage = first;
-		if(![self didStartAnimationForImage: firstPageImage])
+		if([self didStartAnimationForImage: firstPageImage])
 		{
+			[tracker ocrImage:nil];
+		} else {
 			[tracker ocrImage:firstPageImage];
 		}
 	}
@@ -143,9 +145,11 @@ typedef struct {
 	if(second != secondPageImage)
 	{
 		secondPageImage = second;
-		if(![self didStartAnimationForImage: secondPageImage])
+		if([self didStartAnimationForImage: secondPageImage])
 		{
-			[tracker ocrImage:secondPageImage];
+			[tracker ocrImage2:nil];
+		} else {
+			[tracker ocrImage2:secondPageImage];
 		}
 	}
 	
@@ -376,8 +380,11 @@ typedef struct {
 			NSRect frame = [self centerScanRect: secondPageRect];
 			[secondPageLayer setFrame:frame];
 			[newLayer addSublayer:secondPageLayer];
-			[secondPageLayer addSublayer:[tracker layerForImage:secondPageImage imageLayer:secondPageLayer]];
 			CFRelease(secondPageImageRef);
+			CALayer *selectionLayer = [tracker layerForImage:secondPageImage imageLayer:secondPageLayer];
+			if (selectionLayer) {
+				[secondPageLayer addSublayer:selectionLayer];
+			}
 		} else {
 			[secondPageImage drawInRect: [self centerScanRect: secondPageRect]
 							   fromRect: NSZeroRect

--- a/Classes/Touch Bar/TSSTSessionWindowController+NSTouchBar.swift
+++ b/Classes/Touch Bar/TSSTSessionWindowController+NSTouchBar.swift
@@ -10,18 +10,18 @@ import Cocoa
 
 @available(macOS 10.12.2, *)
 extension NSTouchBarItem.Identifier {
-	static let prevNext = NSTouchBarItem.Identifier("com.ToWatchList.prevNextButton")
-	static let pageOrder = NSTouchBarItem.Identifier("com.ToWatchList.pageOrder")
-	static let pageLayout = NSTouchBarItem.Identifier("com.ToWatchList.pageLayout")
-	static let pageScaling = NSTouchBarItem.Identifier("com.ToWatchList.pageScaling")
-	static let rotate = NSTouchBarItem.Identifier("com.ToWatchList.rotatePage")
-	static let scrubber = NSTouchBarItem.Identifier("com.ToWatchList.scrubberBar")
+	static let prevNext = NSTouchBarItem.Identifier("com.turbozen.prevNextButton")
+	static let pageOrder = NSTouchBarItem.Identifier("com.turbozen.pageOrder")
+	static let pageLayout = NSTouchBarItem.Identifier("com.turbozen.pageLayout")
+	static let pageScaling = NSTouchBarItem.Identifier("com.turbozen.pageScaling")
+	static let rotate = NSTouchBarItem.Identifier("com.turbozen.rotatePage")
+	static let scrubber = NSTouchBarItem.Identifier("com.turbozen.scrubberBar")
 }
 
 @available(macOS 10.12.2, *)
 extension TSSTSessionWindowController: NSTouchBarDelegate, NSScrubberDataSource {
 	
-	static let touchBar: NSTouchBar.CustomizationIdentifier = "com.ToWatchList.touchBar"
+	static let touchBar: NSTouchBar.CustomizationIdentifier = "com.turbozen.touchBar"
 	
 	open override func makeTouchBar() -> NSTouchBar? {
 		let touchBar = NSTouchBar()

--- a/Info.plist
+++ b/Info.plist
@@ -437,7 +437,7 @@
 	<key>CFBundleHelpBookFolder</key>
 	<string>SimpleComic Help.help</string>
 	<key>CFBundleHelpBookName</key>
-	<string>com.ToWatchList.SimpleComic.help</string>
+	<string>com.turbozen.SimpleComic.help</string>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>

--- a/README.md
+++ b/README.md
@@ -5,6 +5,21 @@ The basic feature drive is to reduce the number of interactions required to brow
 
 Quick Comic is a bundled quicklook preview and thumbnail generation plugin for cbr and cbz files.
 
+## Oster's changes
+
+Simple Comic uses Apple's Optical Character Recognition to make text in comics selectable for
+copying and text-to-speech.
+
+* The mouse cursor changes from the Arrow to the i-Beam when over selectable text.
+* Click-and-drag to select live text. Recognized words within the dragged out rectangle are selected.
+* **Copy**, **Select All**, and **Speak**, on the **Edit** menu work.
+* Control-click on selected text for a contextual menu with **Copy** and **Speak**
+* ⌘-click-and-drag to add a new selection rectangle to the existing selection.
+
+### TODO: Oster's changes
+
+* two page spreads. Coming soon!
+
 ## Privacy
 
 We don't collect any user data in the app itself. We know nothing about you and are happy with that.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,21 @@ The basic feature drive is to reduce the number of interactions required to brow
 
 Quick Comic is a bundled quicklook preview and thumbnail generation plugin for cbr and cbz files.
 
+## Oster's changes
+
+Simple Comic uses Apple's Optical Character Recognition to make text in comics selectable for
+copying and text-to-speech.
+
+• The mouse cursor changes from the Arrow to the i-Beam when over selectable text.
+• Click-and-drag to select live text. Recognized words within the dragged out rectangle are selected.
+• **Copy**, **Select All**, and **Speak**, on the **Edit** menu work.
+• Control-click on selected text for a contextual menu with **Copy** and **Speak**
+• ⌘-click-and-drag to add a new selection rectangle to the existing selection.
+
+### TODO: Oster's changes
+
+• two page spreads. Coming soon!
+
 ## Privacy
 
 We don't collect any user data in the app itself. We know nothing about you and are happy with that.

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ The basic feature drive is to reduce the number of interactions required to brow
 
 Quick Comic is a bundled quicklook preview and thumbnail generation plugin for cbr and cbz files.
 
-## Oster's changes
+## Apple's Live Text support
 
-Simple Comic uses Apple's Optical Character Recognition to make text in comics selectable for
-copying and text-to-speech.
+Simple Comic uses Apple's Optical Character Recognition, on Apple Silicon Macintoshes, to make text
+in comics selectable for copying and text-to-speech.
 
 * The mouse cursor changes from the Arrow to the i-Beam when over selectable text.
 * Click-and-drag to select live text. Recognized words within the dragged out rectangle are selected.
@@ -16,9 +16,7 @@ copying and text-to-speech.
 * Control-click on selected text for a contextual menu with **Copy** and **Speak**
 * ⌘-click-and-drag to add a new selection rectangle to the existing selection.
 
-### TODO: Oster's changes
-
-* two page spreads. Coming soon!
+* Two page spreads, rotations, page ordering, and zooming all work as expected.
 
 ## Privacy
 

--- a/README.md
+++ b/README.md
@@ -10,15 +10,15 @@ Quick Comic is a bundled quicklook preview and thumbnail generation plugin for c
 Simple Comic uses Apple's Optical Character Recognition to make text in comics selectable for
 copying and text-to-speech.
 
-• The mouse cursor changes from the Arrow to the i-Beam when over selectable text.
-• Click-and-drag to select live text. Recognized words within the dragged out rectangle are selected.
-• **Copy**, **Select All**, and **Speak**, on the **Edit** menu work.
-• Control-click on selected text for a contextual menu with **Copy** and **Speak**
-• ⌘-click-and-drag to add a new selection rectangle to the existing selection.
+* The mouse cursor changes from the Arrow to the i-Beam when over selectable text.
+* Click-and-drag to select live text. Recognized words within the dragged out rectangle are selected.
+* **Copy**, **Select All**, and **Speak**, on the **Edit** menu work.
+* Control-click on selected text for a contextual menu with **Copy** and **Speak**
+* ⌘-click-and-drag to add a new selection rectangle to the existing selection.
 
 ### TODO: Oster's changes
 
-• two page spreads. Coming soon!
+* two page spreads. Coming soon!
 
 ## Privacy
 

--- a/Resources/Base.lproj/MainMenu.xib
+++ b/Resources/Base.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="19158" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="19158"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -135,6 +135,26 @@ CA
                                 <connections>
                                     <action selector="selectAll:" target="-1" id="1935"/>
                                 </connections>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="y8y-na-2L3"/>
+                            <menuItem title="Speech" id="gQR-E6-GF3">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Speech" id="smE-UL-OGJ">
+                                    <items>
+                                        <menuItem title="Start Speaking" id="3QS-jN-jJ4">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="startSpeaking:" target="-1" id="2Br-e6-ei5"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Stop Speaking" id="iTX-FZ-Cma">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="stopSpeaking:" target="-1" id="DgK-rt-oah"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
                             </menuItem>
                         </items>
                     </menu>
@@ -379,10 +399,10 @@ DQ
             <windowStyleMask key="styleMask" titled="YES" nonactivatingPanel="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="292" y="425" width="289" height="138"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="875"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1415"/>
             <value key="minSize" type="size" width="213" height="90"/>
-            <view key="contentView" id="469">
-                <rect key="frame" x="0.0" y="0.0" width="289" height="135"/>
+            <view key="contentView" misplaced="YES" id="469">
+                <rect key="frame" x="0.0" y="0.0" width="289" height="138"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="470" customClass="NSSecureTextField">
@@ -472,10 +492,10 @@ Gw
             <windowStyleMask key="styleMask" titled="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="323" y="210" width="346" height="122"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="875"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1415"/>
             <value key="minSize" type="size" width="213" height="90"/>
-            <view key="contentView" id="1081">
-                <rect key="frame" x="0.0" y="0.0" width="346" height="119"/>
+            <view key="contentView" misplaced="YES" id="1081">
+                <rect key="frame" x="0.0" y="0.0" width="346" height="122"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <popUpButton horizontalHuggingPriority="249" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1082">

--- a/Resources/SimpleComic Help.help/Contents/Info.plist
+++ b/Resources/SimpleComic Help.help/Contents/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en-us</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.ToWatchList.SimpleComic.help</string>
+	<string>com.turbozen.SimpleComic.help</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
@@ -23,7 +23,7 @@
 	<key>HPDBookIndexPath</key>
 	<string>search.helpindex</string>
 	<key>HPDBookKBProduct</key>
-	<string>com.ToWatchList.SimpleComic.help</string>
+	<string>com.turbozen.SimpleComic.help</string>
 	<key>HPDBookIconPath</key>
 	<string>shared/icon.png</string>
 	<key>HPDBookTitle</key>

--- a/Resources/en.lproj/Localizable.strings
+++ b/Resources/en.lproj/Localizable.strings
@@ -1,3 +1,12 @@
+/* The user should never see this menu name */
+"Contextual Menu" = "Contextual Menu";
+
+/* Contextual menu item */
+"Copy" = "Copy";
+
+/* Contextual menu item */
+"Copy Text" = "Copy Text";
+
 /* Pages are scaled to fit window width */
 "Horizontal Fit" = "Horizontal Fit";
 
@@ -49,3 +58,10 @@
 
 /* Scrubber */
 "Scrubber" = "Scrubber";
+
+/* Contextual menu item */
+"Start Speaking" = "Start Speaking";
+
+/* Contextual menu item */
+"Stop Speaking" = "Stop Speaking";
+

--- a/SimpleComic.xcodeproj/project.pbxproj
+++ b/SimpleComic.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 		55FFF1BE1DB01C5E0080B059 /* TSSTPage+CoreDataProperties.m in Sources */ = {isa = PBXBuildFile; fileRef = 55FFF1BC1DB01C5E0080B059 /* TSSTPage+CoreDataProperties.m */; };
 		55FFF1DF1DB020470080B059 /* TSSTManagedGroup+CoreDataProperties.m in Sources */ = {isa = PBXBuildFile; fileRef = 55FFF1DB1DB020470080B059 /* TSSTManagedGroup+CoreDataProperties.m */; };
 		55FFF1E61DB0275C0080B059 /* TSSTManagedSession+CoreDataProperties.m in Sources */ = {isa = PBXBuildFile; fileRef = 55FFF1E41DB0275C0080B059 /* TSSTManagedSession+CoreDataProperties.m */; };
+		638E5C4C2832138400BFDAA4 /* Vision.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 638E5C3C2832138400BFDAA4 /* Vision.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		77C8280E06725ACE000B614F /* SimpleComicAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 77C8280C06725ACE000B614F /* SimpleComicAppDelegate.m */; };
 		8D11072D0486CEB800E47090 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 29B97316FDCFA39411CA2CEA /* main.m */; settings = {ATTRIBUTES = (); }; };
 		8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */; };
@@ -364,6 +365,7 @@
 		55FFF1DB1DB020470080B059 /* TSSTManagedGroup+CoreDataProperties.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "TSSTManagedGroup+CoreDataProperties.m"; sourceTree = "<group>"; };
 		55FFF1E31DB0275C0080B059 /* TSSTManagedSession+CoreDataProperties.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "TSSTManagedSession+CoreDataProperties.h"; sourceTree = "<group>"; };
 		55FFF1E41DB0275C0080B059 /* TSSTManagedSession+CoreDataProperties.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "TSSTManagedSession+CoreDataProperties.m"; sourceTree = "<group>"; };
+		638E5C3C2832138400BFDAA4 /* Vision.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Vision.framework; path = System/Library/Frameworks/Vision.framework; sourceTree = SDKROOT; };
 		64777B8C1A4213100064A356 /* zh-Hans */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/TSSTSessionWindow.strings"; sourceTree = "<group>"; };
 		64777B8D1A4213150064A356 /* zh-Hans */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/MainMenu.strings"; sourceTree = "<group>"; };
 		64777B8E1A42131A0064A356 /* zh-Hans */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Preferences.strings"; sourceTree = "<group>"; };
@@ -405,6 +407,7 @@
 				5500A65D1D7772CD00321300 /* XADMaster.framework in Frameworks */,
 				8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */,
 				286236020AADDB6200B83E77 /* QuartzCore.framework in Frameworks */,
+				638E5C4C2832138400BFDAA4 /* Vision.framework in Frameworks */,
 				28BD08E60C9836E600BD7EAF /* Quartz.framework in Frameworks */,
 				28C1D5600DF1FE37003392B4 /* QuickLook.framework in Frameworks */,
 				285FE3300F945E2300CD8F96 /* Carbon.framework in Frameworks */,
@@ -557,6 +560,7 @@
 		29B97323FDCFA39411CA2CEA /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				638E5C3C2832138400BFDAA4 /* Vision.framework */,
 				559EF3E11BDD390000FAAA0A /* libbz2.tbd */,
 				559EF3DF1BDD38F400FAAA0A /* libz.tbd */,
 				285FE32F0F945E2300CD8F96 /* Carbon.framework */,

--- a/SimpleComic.xcodeproj/project.pbxproj
+++ b/SimpleComic.xcodeproj/project.pbxproj
@@ -68,6 +68,8 @@
 		55FFF1BE1DB01C5E0080B059 /* TSSTPage+CoreDataProperties.m in Sources */ = {isa = PBXBuildFile; fileRef = 55FFF1BC1DB01C5E0080B059 /* TSSTPage+CoreDataProperties.m */; };
 		55FFF1DF1DB020470080B059 /* TSSTManagedGroup+CoreDataProperties.m in Sources */ = {isa = PBXBuildFile; fileRef = 55FFF1DB1DB020470080B059 /* TSSTManagedGroup+CoreDataProperties.m */; };
 		55FFF1E61DB0275C0080B059 /* TSSTManagedSession+CoreDataProperties.m in Sources */ = {isa = PBXBuildFile; fileRef = 55FFF1E41DB0275C0080B059 /* TSSTManagedSession+CoreDataProperties.m */; };
+		6304B5D42840190B009E7D61 /* OCRVision.m in Sources */ = {isa = PBXBuildFile; fileRef = 6304B5D32840190B009E7D61 /* OCRVision.m */; };
+		6304B5D7284019EC009E7D61 /* OCRTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = 6304B5D5284019EC009E7D61 /* OCRTracker.m */; };
 		638E5C4C2832138400BFDAA4 /* Vision.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 638E5C3C2832138400BFDAA4 /* Vision.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		77C8280E06725ACE000B614F /* SimpleComicAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 77C8280C06725ACE000B614F /* SimpleComicAppDelegate.m */; };
 		8D11072D0486CEB800E47090 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 29B97316FDCFA39411CA2CEA /* main.m */; settings = {ATTRIBUTES = (); }; };
@@ -365,6 +367,10 @@
 		55FFF1DB1DB020470080B059 /* TSSTManagedGroup+CoreDataProperties.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "TSSTManagedGroup+CoreDataProperties.m"; sourceTree = "<group>"; };
 		55FFF1E31DB0275C0080B059 /* TSSTManagedSession+CoreDataProperties.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "TSSTManagedSession+CoreDataProperties.h"; sourceTree = "<group>"; };
 		55FFF1E41DB0275C0080B059 /* TSSTManagedSession+CoreDataProperties.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "TSSTManagedSession+CoreDataProperties.m"; sourceTree = "<group>"; };
+		6304B5D22840190B009E7D61 /* OCRVision.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OCRVision.h; sourceTree = "<group>"; };
+		6304B5D32840190B009E7D61 /* OCRVision.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OCRVision.m; sourceTree = "<group>"; };
+		6304B5D5284019EC009E7D61 /* OCRTracker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OCRTracker.m; sourceTree = "<group>"; };
+		6304B5D6284019EC009E7D61 /* OCRTracker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OCRTracker.h; sourceTree = "<group>"; };
 		638E5C3C2832138400BFDAA4 /* Vision.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Vision.framework; path = System/Library/Frameworks/Vision.framework; sourceTree = SDKROOT; };
 		64777B8C1A4213100064A356 /* zh-Hans */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/TSSTSessionWindow.strings"; sourceTree = "<group>"; };
 		64777B8D1A4213150064A356 /* zh-Hans */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/MainMenu.strings"; sourceTree = "<group>"; };
@@ -656,6 +662,17 @@
 			path = "Touch Bar";
 			sourceTree = "<group>";
 		};
+		6304B5C2284018E9009E7D61 /* OCRVision */ = {
+			isa = PBXGroup;
+			children = (
+				6304B5D6284019EC009E7D61 /* OCRTracker.h */,
+				6304B5D5284019EC009E7D61 /* OCRTracker.m */,
+				6304B5D22840190B009E7D61 /* OCRVision.h */,
+				6304B5D32840190B009E7D61 /* OCRVision.m */,
+			);
+			path = OCRVision;
+			sourceTree = "<group>";
+		};
 		FA9FB59508AAE3690085AA55 /* Preferences */ = {
 			isa = PBXGroup;
 			children = (
@@ -674,6 +691,7 @@
 				FA7257EF08A6CE2E006A2A19 /* TSSTPageView.m */,
 				284D381A101249BE00A37AB2 /* DTToolbarItems.swift */,
 				28B34A721013779B006C551C /* NSWindow+Extensions.swift */,
+				6304B5C2284018E9009E7D61 /* OCRVision */,
 			);
 			path = Session;
 			sourceTree = "<group>";
@@ -962,9 +980,11 @@
 			files = (
 				5599515E1BDC0A400086661A /* DTPolishedProgressBar.swift in Sources */,
 				55861E3923C68B3700390CD3 /* V1ToV2.xcmappingmodel in Sources */,
+				6304B5D42840190B009E7D61 /* OCRVision.m in Sources */,
 				8D11072D0486CEB800E47090 /* main.m in Sources */,
 				55C7D78C1C4C0401005F40C8 /* TSSTCircularImageView.swift in Sources */,
 				5590EB3A24A1FD0900DA060E /* ManagedSmartFolder+CoreDataProperties.m in Sources */,
+				6304B5D7284019EC009E7D61 /* OCRTracker.m in Sources */,
 				77C8280E06725ACE000B614F /* SimpleComicAppDelegate.m in Sources */,
 				FA9FB53508AADA270085AA55 /* TSSTCustomValueTransformers.m in Sources */,
 				552627911BDEEC5E005AAF63 /* TSSTKeyWindow.swift in Sources */,

--- a/SimpleComic.xcodeproj/project.pbxproj
+++ b/SimpleComic.xcodeproj/project.pbxproj
@@ -70,6 +70,7 @@
 		55FFF1E61DB0275C0080B059 /* TSSTManagedSession+CoreDataProperties.m in Sources */ = {isa = PBXBuildFile; fileRef = 55FFF1E41DB0275C0080B059 /* TSSTManagedSession+CoreDataProperties.m */; };
 		6304B5D42840190B009E7D61 /* OCRVision.m in Sources */ = {isa = PBXBuildFile; fileRef = 6304B5D32840190B009E7D61 /* OCRVision.m */; };
 		6304B5D7284019EC009E7D61 /* OCRTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = 6304B5D5284019EC009E7D61 /* OCRTracker.m */; };
+		6304B60A28411F13009E7D61 /* OCRSelectionLayer.m in Sources */ = {isa = PBXBuildFile; fileRef = 6304B60928411F13009E7D61 /* OCRSelectionLayer.m */; };
 		638E5C4C2832138400BFDAA4 /* Vision.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 638E5C3C2832138400BFDAA4 /* Vision.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		77C8280E06725ACE000B614F /* SimpleComicAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 77C8280C06725ACE000B614F /* SimpleComicAppDelegate.m */; };
 		8D11072D0486CEB800E47090 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 29B97316FDCFA39411CA2CEA /* main.m */; settings = {ATTRIBUTES = (); }; };
@@ -371,6 +372,8 @@
 		6304B5D32840190B009E7D61 /* OCRVision.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OCRVision.m; sourceTree = "<group>"; };
 		6304B5D5284019EC009E7D61 /* OCRTracker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OCRTracker.m; sourceTree = "<group>"; };
 		6304B5D6284019EC009E7D61 /* OCRTracker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OCRTracker.h; sourceTree = "<group>"; };
+		6304B5F928411F13009E7D61 /* OCRSelectionLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OCRSelectionLayer.h; sourceTree = "<group>"; };
+		6304B60928411F13009E7D61 /* OCRSelectionLayer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OCRSelectionLayer.m; sourceTree = "<group>"; };
 		638E5C3C2832138400BFDAA4 /* Vision.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Vision.framework; path = System/Library/Frameworks/Vision.framework; sourceTree = SDKROOT; };
 		64777B8C1A4213100064A356 /* zh-Hans */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/TSSTSessionWindow.strings"; sourceTree = "<group>"; };
 		64777B8D1A4213150064A356 /* zh-Hans */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/MainMenu.strings"; sourceTree = "<group>"; };
@@ -665,6 +668,8 @@
 		6304B5C2284018E9009E7D61 /* OCRVision */ = {
 			isa = PBXGroup;
 			children = (
+				6304B5F928411F13009E7D61 /* OCRSelectionLayer.h */,
+				6304B60928411F13009E7D61 /* OCRSelectionLayer.m */,
 				6304B5D6284019EC009E7D61 /* OCRTracker.h */,
 				6304B5D5284019EC009E7D61 /* OCRTracker.m */,
 				6304B5D22840190B009E7D61 /* OCRVision.h */,
@@ -981,6 +986,7 @@
 				5599515E1BDC0A400086661A /* DTPolishedProgressBar.swift in Sources */,
 				55861E3923C68B3700390CD3 /* V1ToV2.xcmappingmodel in Sources */,
 				6304B5D42840190B009E7D61 /* OCRVision.m in Sources */,
+				6304B60A28411F13009E7D61 /* OCRSelectionLayer.m in Sources */,
 				8D11072D0486CEB800E47090 /* main.m in Sources */,
 				55C7D78C1C4C0401005F40C8 /* TSSTCircularImageView.swift in Sources */,
 				5590EB3A24A1FD0900DA060E /* ManagedSmartFolder+CoreDataProperties.m in Sources */,

--- a/SimpleComic.xcodeproj/project.pbxproj
+++ b/SimpleComic.xcodeproj/project.pbxproj
@@ -746,11 +746,11 @@
 				TargetAttributes = {
 					55C374041BD9E67D006385B6 = {
 						CreatedOnToolsVersion = 7.1;
-						DevelopmentTeam = 3D9SMH4RWM;
+						DevelopmentTeam = 2X3M9VFULE;
 						ProvisioningStyle = Automatic;
 					};
 					8D1107260486CEB800E47090 = {
-						DevelopmentTeam = 3D9SMH4RWM;
+						DevelopmentTeam = 2X3M9VFULE;
 						LastSwiftMigration = 1100;
 						ProvisioningStyle = Automatic;
 						SystemCapabilities = {
@@ -1127,7 +1127,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 273;
-				DEVELOPMENT_TEAM = 3D9SMH4RWM;
+				DEVELOPMENT_TEAM = 2X3M9VFULE;
 				EXPORTED_SYMBOLS_FILE = QuickComic/QuickComic.exp;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -1139,7 +1139,7 @@
 				INSTALL_PATH = /Library/QuickLook;
 				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../../../../../Frameworks $(inherited)";
 				MARKETING_VERSION = 0.5;
-				PRODUCT_BUNDLE_IDENTIFIER = com.ToWatchList.SimpleComic.quickcomic;
+				PRODUCT_BUNDLE_IDENTIFIER = com.turbozen.SimpleComic.quickcomic;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
@@ -1156,14 +1156,14 @@
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 273;
 				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_TEAM = 3D9SMH4RWM;
+				DEVELOPMENT_TEAM = 2X3M9VFULE;
 				EXPORTED_SYMBOLS_FILE = QuickComic/QuickComic.exp;
 				GCC_NO_COMMON_BLOCKS = YES;
 				INFOPLIST_FILE = QuickComic/Info.plist;
 				INSTALL_PATH = /Library/QuickLook;
 				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../../../../../Frameworks $(inherited)";
 				MARKETING_VERSION = 0.5;
-				PRODUCT_BUNDLE_IDENTIFIER = com.ToWatchList.SimpleComic.quickcomic;
+				PRODUCT_BUNDLE_IDENTIFIER = com.turbozen.SimpleComic.quickcomic;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
@@ -1184,8 +1184,8 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 274;
-				DEVELOPMENT_TEAM = 3D9SMH4RWM;
+				CURRENT_PROJECT_VERSION = 275;
+				DEVELOPMENT_TEAM = 2X3M9VFULE;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
@@ -1194,9 +1194,9 @@
 				INFOPLIST_FILE = Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks @executable_path/../Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(SRCROOT)";
-				MARKETING_VERSION = 1.9.2;
+				MARKETING_VERSION = 1.9.3;
 				OTHER_LDFLAGS = "";
-				PRODUCT_BUNDLE_IDENTIFIER = com.ToWatchList.SimpleComic;
+				PRODUCT_BUNDLE_IDENTIFIER = com.turbozen.SimpleComic;
 				PRODUCT_NAME = "Simple Comic";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				STRIP_SWIFT_SYMBOLS = NO;
@@ -1218,9 +1218,9 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = YES;
-				CURRENT_PROJECT_VERSION = 274;
+				CURRENT_PROJECT_VERSION = 275;
 				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_TEAM = 3D9SMH4RWM;
+				DEVELOPMENT_TEAM = 2X3M9VFULE;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
 				GCC_THREADSAFE_STATICS = YES;
@@ -1229,8 +1229,8 @@
 				INFOPLIST_FILE = Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks @executable_path/../Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(SRCROOT)";
-				MARKETING_VERSION = 1.9.2;
-				PRODUCT_BUNDLE_IDENTIFIER = com.ToWatchList.SimpleComic;
+				MARKETING_VERSION = 1.9.3;
+				PRODUCT_BUNDLE_IDENTIFIER = com.turbozen.SimpleComic;
 				PRODUCT_NAME = "Simple Comic";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				STRIP_INSTALLED_PRODUCT = YES;
@@ -1269,7 +1269,7 @@
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				CODE_SIGN_IDENTITY = "Apple Distribution: Nicholas Vance (3D9SMH4RWM)";
+				CODE_SIGN_IDENTITY = "Apple Development: David Phillip Oster (FSSYVLKLJK)";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
@@ -1320,7 +1320,7 @@
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				CODE_SIGN_IDENTITY = "Apple Distribution: Nicholas Vance (3D9SMH4RWM)";
+				CODE_SIGN_IDENTITY = "Apple Development: David Phillip Oster (FSSYVLKLJK)";
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;


### PR DESCRIPTION
The OCR branch in my fork of Simple-Comic implements issue:#69 Live Text. You'll want to omit my change b3e4cb6 (it is just before the commit tagged: "OCRStart") which temporarily changes the bundle ID and the DEVELOPMENT_TEAM to me. 

I made minimal changes to TSSTPageView, putting most of the code in a new subdirectory of Classes/Sessions called  OCRVision. As the revised README.md says:

* The mouse cursor changes from the Arrow to the i-Beam when over selectable text.
* Click-and-drag to select live text. Recognized words within the dragged out rectangle are selected.
* **Copy**, **Select All**, and **Speak**, on the **Edit** menu work.
* Control-click on selected text for a contextual menu with **Copy** and **Speak**
* ⌘-click-and-drag to add a new selection rectangle to the existing selection.

* Two page spreads, rotations, page ordering, and zooming all work as expected.
