### PR TITLE
Hide cursor in fullscreen

### DIFF
--- a/Classes/Session/TSSTSessionWindowController.m
+++ b/Classes/Session/TSSTSessionWindowController.m
@@ -1063,6 +1063,7 @@ NSString * const TSSTMouseDragNotification = @"SCMouseDragNotification";
 
 - (void)hideCursor
 {
+	[mouseMovedTimer invalidate];
 	mouseMovedTimer = nil;
 	[NSCursor setHiddenUntilMouseMoves: YES];
 }

--- a/Classes/Session/TSSTSessionWindowController.m
+++ b/Classes/Session/TSSTSessionWindowController.m
@@ -304,6 +304,8 @@ NSString * const TSSTMouseDragNotification = @"SCMouseDragNotification";
 	}
 	
 	[self refreshLoupePanel];
+	
+	[self handleFullscreenCursorHiding];
 }
 
 
@@ -397,6 +399,15 @@ NSString * const TSSTMouseDragNotification = @"SCMouseDragNotification";
 					   right: NSMaxX([[bar window] frame])];
 }
 
+- (void)handleFullscreenCursorHiding
+{
+	if ([[self window] isFullscreen])
+	{
+		// Invalidate eventual previous timer to prevent cursor flickering
+		[mouseMovedTimer invalidate];
+		mouseMovedTimer = [NSTimer scheduledTimerWithTimeInterval:1.0 target:self selector:@selector(hideCursor) userInfo:nil repeats:NO];
+	}
+}
 
 #pragma mark - Actions
 
@@ -1053,11 +1064,7 @@ NSString * const TSSTMouseDragNotification = @"SCMouseDragNotification";
 - (void)hideCursor
 {
 	mouseMovedTimer = nil;
-
-	if([[self window] isFullscreen])
-	{
-		[NSCursor setHiddenUntilMouseMoves: YES];
-	}
+	[NSCursor setHiddenUntilMouseMoves: YES];
 }
 
 


### PR DESCRIPTION
Hello,

When using the app (which is very good), I found that it lacked the standard "Hide cursor when in fullscreen" feature.

I then quickly browsed through the code, and noticed that a `NSTimer mouseMovedTimer` object and a `hideCursor` function existed, but were never used/called.

So I just added a `handleFullscreenCursorHiding` function which is called when the `mouseMoved` event is triggered. It takes care of initializing and invalidating the timer when necessary. After a bit of testing, I set the timeout to 1 second, which feels natural (at least to me 😅). I don't check whether the timer is `nil` when trying to invalidate it since after testing, nothing yells at me, either at runtime or at compile time (even though it is explicitly set to `nil` in the `init` and `hideCursor` functions). I guess that's an Objective-C thing (well I just checked and it is 😅).

I also moved the if-statement that checks if the app is in fullscreen to this new function, so that the 'convenience function' `hideCursor` called when the timer fires just does that (as well as setting the timer back to `nil`).

I'd like to apologize in advance if I violated some 'Pull request' or Objective-C 'convention', since it's literally my first time looking at code written in this language (it's also my first pull request ever).

Thank you for your work, and for taking the time to take a look at this really simple fix (if by any chance you do)!