### PR TITLE
Hide cursor in fullscreen: improvements

### DIFF
--- a/Classes/Session/TSSTSessionWindowController.m
+++ b/Classes/Session/TSSTSessionWindowController.m
@@ -1640,6 +1640,7 @@ NSString * const TSSTMouseDragNotification = @"SCMouseDragNotification";
 			[NSCursor hide];
 		}
 		[self refreshLoupePanel];
+		[self handleFullscreenCursorHiding];
     }
 }
 
@@ -1816,6 +1817,13 @@ NSString * const TSSTMouseDragNotification = @"SCMouseDragNotification";
 {
 //    [self resizeWindow];
 	[self refreshLoupePanel];
+	[self hideCursor];
+}
+
+- (void)windowWillExitFullScreen:(NSNotification *)notification
+{
+	[mouseMovedTimer invalidate];
+	mouseMovedTimer = nil;
 }
 
 - (void)windowDidExitFullScreen:(NSNotification *)notification


### PR DESCRIPTION
Hello,

Following up on #94, I found that having to move the cursor again for it to be hidden after the window regains focus when 'Cmd+Tab'-ing into it was pretty annoying and felt unnatural.

To fix this, I added a call to `handleFullscreenCursorHiding` in the delegate function `windowDidBecomeKey`. I didn't directly check if the window was in fullscreen mode in order to hide the cursor instantly because it seems that the window property `isFullscreen` is not set yet when this function is called. The delegate functions `windowDidEnterFullScreen` and `windowWillEnterFullScreen` are not called either when the window regains focus, so I didn't use those either.

I also added a call to `handleFullscreenCursorHiding` in `windowDidEnterFullScreen` which directly hides the cursor without delay when entering fullscreen mode, since it also feels more 'native' this way.

Finally, I implemented the delegate function `windowWillExitFullScreen` in which I invalidate the `mouseMovedTimer` and set it to nil, to prevent the cursor from hiding again after exiting fullscreen mode.

I am well aware that those small changes might seem insignificant at first, but they really add to the overall fullscreen experience of the app, and make it behave a bit more as expected.

Again, thank you for your time!