### PR TITLE
fix: in the about box set the colors of the text to Apple's standard text colors

### DIFF
--- a/Resources/en.lproj/Credits.rtf
+++ b/Resources/en.lproj/Credits.rtf
@@ -1,7 +1,7 @@
 {\rtf1\ansi\ansicpg1252\cocoartf2709
 \cocoatextscaling0\cocoaplatform0{\fonttbl\f0\fswiss\fcharset0 Helvetica-Bold;\f1\fswiss\fcharset0 Helvetica;}
-{\colortbl;\red255\green255\blue255;\red69\green39\blue1;}
-{\*\expandedcolortbl;;\cssrgb\c34339\c20326\c0;}
+{\colortbl;\red255\green255\blue255;\red0\green0\blue0;}
+{\*\expandedcolortbl;;\csgray\c0;}
 \vieww20520\viewh15240\viewkind0
 \pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\pardirnatural\qc\partightenfactor0
 


### PR DESCRIPTION
including dark mode support. They had been brown. Tested by viewing the credits both in light mode and dark mode.