### PR TITLE
Add a paper-look reading mode (paper effect)

### DIFF
--- a/Classes/Session/PaperKernels.metal
+++ b/Classes/Session/PaperKernels.metal
@@ -1,0 +1,86 @@
+//
+//  PaperKernels.metal
+//  Simple Comic
+//
+//  Core Image Metal kernel that overlays an organic paper texture on an
+//  already tone-mapped page. It models real printed paper two ways at once:
+//
+//    * a subtle MULTIPLY "body" that gives the light paper stock its tooth
+//      (and barely touches dense ink), and
+//    * a SCREEN "show-through": the cream paper fibres peeking THROUGH the
+//      ink, which lightens dark / saturated areas the most and leaves the
+//      light stock almost untouched — the charm of a printed comic.
+//
+//  Built with -fcikernel (compile) + -cikernel (metallib link); see the target
+//  build settings. Loaded via CIKernel(functionName:fromMetalLibraryData:).
+//
+
+#include <metal_stdlib>
+#include <CoreImage/CoreImage.h>
+using namespace metal;
+
+static inline float sc_hash(float2 p)
+{
+	p = fract(p * float2(123.34, 456.21));
+	p += dot(p, p + 45.32);
+	return fract(p.x * p.y);
+}
+
+static inline float sc_valueNoise(float2 p)
+{
+	float2 i = floor(p);
+	float2 f = fract(p);
+	float2 u = f * f * (3.0 - 2.0 * f);
+	float a = sc_hash(i);
+	float b = sc_hash(i + float2(1.0, 0.0));
+	float c = sc_hash(i + float2(0.0, 1.0));
+	float d = sc_hash(i + float2(1.0, 1.0));
+	return mix(mix(a, b, u.x), mix(c, d, u.x), u.y);
+}
+
+static inline float sc_fbm(float2 p)
+{
+	float n = 0.0;
+	float amp = 0.5;
+	// Rotate every octave — including the first, strongest one — so the
+	// value-noise lattice is never axis-aligned. This removes the
+	// horizontal/vertical seams and gives an even, directionless grain.
+	const float2x2 rot = float2x2(0.80, 0.60, -0.60, 0.80);
+	p = rot * (p + 4.7);
+	for (int i = 0; i < 5; i++) {
+		n += amp * sc_valueNoise(p);
+		p = rot * (p * 2.02);
+		amp *= 0.5;
+	}
+	return n;
+}
+
+extern "C" float4 paperTexture(coreimage::sampler src,
+							   float grainStrength,   // MULTIPLY body on the light stock
+							   float peekStrength,    // SCREEN paper peeking through ink
+							   float scale,           // fibre size in pixels
+							   float3 paperTint,      // cream colour of the peek-through
+							   coreimage::destination dest)
+{
+	float4 c = src.sample(src.coord());
+	float2 p = dest.coord() / max(scale, 0.5);
+
+	// Even, directionless paper grain (no horizontal or vertical bias) — the
+	// per-octave rotation in sc_fbm keeps the lattice off-axis so there are no
+	// seams in any direction.
+	float fibre = clamp(sc_fbm(p), 0.0, 1.0);
+
+	float L = dot(c.rgb, float3(0.299, 0.587, 0.114));
+	float3 rgb = c.rgb;
+
+	// (a) Paper body — subtle darkening, mostly on the light stock.
+	float bodyW = smoothstep(0.10, 0.55, L);
+	rgb *= 1.0 + (fibre - 0.5) * grainStrength * bodyW;
+
+	// (b) Paper peeking through — screen the cream fibre highlights.
+	float peak = pow(fibre, 2.2);
+	float3 s = paperTint * (peak * peekStrength);
+	rgb = 1.0 - (1.0 - rgb) * (1.0 - s);
+
+	return float4(clamp(rgb, 0.0, 1.0), c.a);
+}

--- a/Classes/Session/SCPaperFilter.swift
+++ b/Classes/Session/SCPaperFilter.swift
@@ -1,0 +1,211 @@
+//
+//  SCPaperFilter.swift
+//  Simple Comic
+//
+//  Applies a "paper" look to comic pages: harsh blacks are lifted to a dark
+//  warm grey, the white point is pulled towards a warm cream, and an organic
+//  paper texture is laid over the page. The texture is applied two ways at
+//  once (see PaperKernels.metal): a subtle MULTIPLY that gives the light stock
+//  its tooth, and a SCREEN "show-through" so the cream paper fibres peek
+//  through the ink — which is what makes a printed comic feel like paper.
+//
+//  All parameters are read live from NSUserDefaults so they can be tuned at
+//  runtime (see the "Paper Effect Settings…" panel). The heavy lifting runs on
+//  a Metal Core Image kernel; if that can not be loaded we fall back to a
+//  pure Core Image approximation so the effect always works.
+//
+//  The effect is applied non-destructively at display time (see TSSTPageView);
+//  the original NSImage is never modified.
+//
+
+import AppKit
+import CoreImage
+import Metal
+
+@objc(SCPaperFilter)
+final class SCPaperFilter: NSObject {
+
+	/// Shared instance – keeps a single (Metal-backed) CIContext + kernel alive.
+	/// `nonisolated(unsafe)` is safe here: the instance is immutable after init
+	/// and CIContext is documented as thread-safe.
+	@objc(sharedFilter)
+	nonisolated(unsafe) static let shared = SCPaperFilter()
+
+	// MARK: - User-defaults keys & registered defaults
+
+	@objc static let enabledKey     = "SCPaperEffectEnabled"
+	@objc static let showThroughKey = "SCPaperShowThrough"
+	@objc static let grainKey       = "SCPaperGrain"
+	@objc static let warmthKey      = "SCPaperWarmth"
+	@objc static let blackLiftKey   = "SCPaperBlackLift"
+	@objc static let fiberScaleKey  = "SCPaperFiberScale"
+
+	/// Posted (on the main thread) whenever a parameter changes so views can
+	/// drop their cached filtered image and redraw.
+	@objc static let settingsChangedNotification = Notification.Name("SCPaperSettingsChanged")
+
+	/// Registered so `-boolForKey:`/`-doubleForKey:` return sensible values.
+	@objc static let registeredDefaults: [String: Any] = [
+		enabledKey: false,
+		showThroughKey: 0.38,
+		grainKey: 0.14,
+		warmthKey: 1.0,
+		blackLiftKey: 1.0,
+		fiberScaleKey: 2.0,
+	]
+
+	// MARK: - Rendering
+
+	private let context: CIContext
+	private let kernel: CIKernel?    // Metal paperTexture; nil => CI fallback.
+	private let outputColorSpace = CGColorSpace(name: CGColorSpace.sRGB)!
+
+	override init() {
+		// NSNull working space => filters operate directly on the (sRGB encoded)
+		// pixel values, giving intuitive "levels"-style tonal math.
+		let options: [CIContextOption: Any] = [.workingColorSpace: NSNull()]
+		if let device = MTLCreateSystemDefaultDevice() {
+			context = CIContext(mtlDevice: device, options: options)
+		} else {
+			context = CIContext(options: options)
+		}
+		kernel = SCPaperFilter.loadKernel()
+		super.init()
+	}
+
+	private static func loadKernel() -> CIKernel? {
+		guard let url = Bundle.main.url(forResource: "default", withExtension: "metallib"),
+			  let data = try? Data(contentsOf: url) else { return nil }
+		return try? CIKernel(functionName: "paperTexture", fromMetalLibraryData: data)
+	}
+
+	/// Returns a new NSImage with the paper effect applied, or `nil` if the
+	/// image can not be rendered.
+	@objc(paperImageFromImage:)
+	func paperImage(from image: NSImage) -> NSImage? {
+		var proposed = NSRect(origin: .zero, size: image.size)
+		guard let source = image.cgImage(forProposedRect: &proposed, context: nil, hints: nil) else {
+			return nil
+		}
+		let input = CIImage(cgImage: source)
+		let output = applyPaperEffect(to: input)
+		guard let rendered = context.createCGImage(output,
+												   from: input.extent,
+												   format: .RGBA8,
+												   colorSpace: outputColorSpace) else {
+			return nil
+		}
+		return NSImage(cgImage: rendered,
+					   size: NSSize(width: rendered.width, height: rendered.height))
+	}
+
+	// MARK: - Parameters (read live from user defaults)
+
+	private struct Params {
+		var showThrough, grain, warmth, blackLift, fiberScale: CGFloat
+	}
+
+	private func currentParams() -> Params {
+		let d = UserDefaults.standard
+		func value(_ key: String, _ fallback: Double) -> CGFloat {
+			d.object(forKey: key) == nil ? CGFloat(fallback) : CGFloat(d.double(forKey: key))
+		}
+		return Params(showThrough: value(Self.showThroughKey, 0.38),
+					  grain:       value(Self.grainKey, 0.14),
+					  warmth:      value(Self.warmthKey, 1.0),
+					  blackLift:   value(Self.blackLiftKey, 1.0),
+					  fiberScale:  max(value(Self.fiberScaleKey, 2.0), 0.5))
+	}
+
+	/// Interpolates the tonal endpoints between a neutral grey paper (warmth 0)
+	/// and a warm cream stock (warmth 1); `blackLift` scales how far pure black
+	/// is raised (0 = pure black / high contrast, 1 = full soft lift).
+	private func tones(warmth: CGFloat, blackLift: CGFloat)
+		-> (floor: CIVector, ceil: CIVector, tint: CIVector) {
+		func lerp(_ a: (Double, Double, Double), _ b: (Double, Double, Double), _ t: CGFloat)
+			-> (Double, Double, Double) {
+			let tt = Double(t)
+			return (a.0 + (b.0 - a.0) * tt, a.1 + (b.1 - a.1) * tt, a.2 + (b.2 - a.2) * tt)
+		}
+		let neutralFloor = (0.145, 0.145, 0.145), warmFloor = (0.16, 0.14, 0.11)
+		let neutralCeil  = (0.93, 0.93, 0.93),    warmCeil  = (0.96, 0.92, 0.82)
+		let neutralTint  = (0.92, 0.92, 0.92),    warmTint  = (0.95, 0.90, 0.78)
+
+		let fl = lerp(neutralFloor, warmFloor, warmth)
+		let ce = lerp(neutralCeil,  warmCeil,  warmth)
+		let ti = lerp(neutralTint,  warmTint,  warmth)
+		let bl = Double(blackLift)
+		return (CIVector(x: fl.0 * bl, y: fl.1 * bl, z: fl.2 * bl),
+				CIVector(x: ce.0, y: ce.1, z: ce.2),
+				CIVector(x: ti.0, y: ti.1, z: ti.2))
+	}
+
+	// MARK: - Pipeline
+
+	private func applyPaperEffect(to input: CIImage) -> CIImage {
+		let p = currentParams()
+		let t = tones(warmth: p.warmth, blackLift: p.blackLift)
+
+		// 1. Compress tonal range + tint: out = in * (ceil - floor) + floor.
+		let sR = t.ceil.x - t.floor.x, sG = t.ceil.y - t.floor.y, sB = t.ceil.z - t.floor.z
+		var toned = input.applyingFilter("CIColorMatrix", parameters: [
+			"inputRVector": CIVector(x: sR, y: 0, z: 0, w: 0),
+			"inputGVector": CIVector(x: 0, y: sG, z: 0, w: 0),
+			"inputBVector": CIVector(x: 0, y: 0, z: sB, w: 0),
+			"inputAVector": CIVector(x: 0, y: 0, z: 0, w: 1),
+			"inputBiasVector": CIVector(x: t.floor.x, y: t.floor.y, z: t.floor.z, w: 0),
+		])
+		// 2. Gentle desaturation + soft contrast for a matte, printed feel.
+		toned = toned.applyingFilter("CIColorControls", parameters: [
+			kCIInputSaturationKey: 0.92,
+			kCIInputContrastKey: 0.96,
+		])
+
+		// 3. Organic paper texture (Metal), with a Core Image fallback.
+		if let kernel = kernel {
+			let textured = kernel.apply(extent: input.extent,
+										roiCallback: { _, rect in rect },
+										arguments: [toned, p.grain, p.showThrough, p.fiberScale, t.tint])
+			if let textured = textured {
+				return textured.cropped(to: input.extent)
+			}
+		}
+		return fallbackTexture(on: toned, tint: t.tint, grain: p.grain, showThrough: p.showThrough)
+			.cropped(to: input.extent)
+	}
+
+	/// Pure Core Image approximation used when the Metal kernel is unavailable:
+	/// a softened multiply grain for the body + a screen highlight for show-through.
+	private func fallbackTexture(on toned: CIImage, tint: CIVector,
+								 grain: CGFloat, showThrough: CGFloat) -> CIImage {
+		let extent = toned.extent
+		guard let gen = CIFilter(name: "CIRandomGenerator")?.outputImage else { return toned }
+		var fiber = gen.applyingFilter("CIColorControls", parameters: [kCIInputSaturationKey: 0.0])
+		fiber = fiber.transformed(by: CGAffineTransform(scaleX: 2.0, y: 1.0))
+		fiber = fiber.clampedToExtent()
+			.applyingFilter("CIGaussianBlur", parameters: [kCIInputRadiusKey: 1.1])
+			.cropped(to: extent)
+
+		let m = grain
+		let mult = fiber.applyingFilter("CIColorMatrix", parameters: [
+			"inputRVector": CIVector(x: m, y: 0, z: 0, w: 0),
+			"inputGVector": CIVector(x: 0, y: m, z: 0, w: 0),
+			"inputBVector": CIVector(x: 0, y: 0, z: m, w: 0),
+			"inputAVector": CIVector(x: 0, y: 0, z: 0, w: 0),
+			"inputBiasVector": CIVector(x: 1 - m, y: 1 - m, z: 1 - m, w: 1),
+		])
+		var out = mult.applyingFilter("CIMultiplyBlendMode", parameters: [kCIInputBackgroundImageKey: toned])
+
+		let peaks = fiber.applyingFilter("CIGammaAdjust", parameters: ["inputPower": 2.2])
+		let s = showThrough
+		let peek = peaks.applyingFilter("CIColorMatrix", parameters: [
+			"inputRVector": CIVector(x: tint.x * s, y: 0, z: 0, w: 0),
+			"inputGVector": CIVector(x: 0, y: tint.y * s, z: 0, w: 0),
+			"inputBVector": CIVector(x: 0, y: 0, z: tint.z * s, w: 0),
+			"inputAVector": CIVector(x: 0, y: 0, z: 0, w: 0),
+			"inputBiasVector": CIVector(x: 0, y: 0, z: 0, w: 1),
+		])
+		out = out.applyingFilter("CIScreenBlendMode", parameters: [kCIInputBackgroundImageKey: peek])
+		return out
+	}
+}

--- a/Classes/Session/SCPaperSettingsController.swift
+++ b/Classes/Session/SCPaperSettingsController.swift
@@ -1,0 +1,165 @@
+//
+//  SCPaperSettingsController.swift
+//  Simple Comic
+//
+//  A small floating panel that lets the user tune the paper effect live:
+//  sliders for show-through / grain / warmth / black-lift plus a few presets.
+//  Everything is stored in NSUserDefaults (see SCPaperFilter) and a change
+//  posts SCPaperFilter.settingsChangedNotification so open sessions redraw.
+//
+
+import AppKit
+
+@MainActor
+@objc(SCPaperSettingsController)
+final class SCPaperSettingsController: NSObject {
+
+	@objc(sharedController)
+	static let shared = SCPaperSettingsController()
+
+	private struct Knob {
+		let key: String
+		let title: String
+		let min: Double
+		let max: Double
+	}
+
+	private let knobs: [Knob] = [
+		Knob(key: SCPaperFilter.showThroughKey, title: "Paper show-through", min: 0.0, max: 0.8),
+		Knob(key: SCPaperFilter.grainKey,       title: "Grain",             min: 0.0, max: 0.4),
+		Knob(key: SCPaperFilter.warmthKey,      title: "Warmth",            min: 0.0, max: 1.0),
+		Knob(key: SCPaperFilter.blackLiftKey,   title: "Black lift",        min: 0.0, max: 1.0),
+	]
+
+	/// Preset name + the parameter bundle it sets.
+	private let presets: [(name: String, values: [String: Double])] = [
+		("Cream paper", [SCPaperFilter.showThroughKey: 0.38, SCPaperFilter.grainKey: 0.14,
+						 SCPaperFilter.warmthKey: 1.0, SCPaperFilter.blackLiftKey: 1.0]),
+		("Newsprint",   [SCPaperFilter.showThroughKey: 0.52, SCPaperFilter.grainKey: 0.22,
+						 SCPaperFilter.warmthKey: 0.55, SCPaperFilter.blackLiftKey: 1.0]),
+		("Manga",       [SCPaperFilter.showThroughKey: 0.20, SCPaperFilter.grainKey: 0.09,
+						 SCPaperFilter.warmthKey: 0.25, SCPaperFilter.blackLiftKey: 0.85]),
+		("E-Ink",       [SCPaperFilter.showThroughKey: 0.30, SCPaperFilter.grainKey: 0.12,
+						 SCPaperFilter.warmthKey: 0.0, SCPaperFilter.blackLiftKey: 1.0]),
+	]
+
+	private var panel: NSPanel?
+	private var sliders: [String: NSSlider] = [:]
+	private var valueLabels: [String: NSTextField] = [:]
+	private var presetPopup: NSPopUpButton?
+
+	@objc func showPanel(_ sender: Any?) {
+		if panel == nil { panel = buildPanel() }
+		syncControls()
+		panel?.center()
+		panel?.makeKeyAndOrderFront(sender)
+	}
+
+	// MARK: - Building
+
+	private func buildPanel() -> NSPanel {
+		let grid = NSGridView()
+		grid.translatesAutoresizingMaskIntoConstraints = false
+		grid.rowSpacing = 10
+		grid.columnSpacing = 10
+
+		let popup = NSPopUpButton(frame: .zero, pullsDown: false)
+		popup.addItems(withTitles: presets.map { NSLocalizedString($0.name, comment: "Paper effect preset name") }
+					   + [NSLocalizedString("Custom", comment: "Paper effect preset: user-adjusted values")])
+		popup.target = self
+		popup.action = #selector(presetChanged(_:))
+		presetPopup = popup
+		grid.addRow(with: [label(NSLocalizedString("Preset", comment: "Paper effect preset picker label")),
+						   popup, NSGridCell.emptyContentView])
+
+		for knob in knobs {
+			let slider = NSSlider(value: knob.min, minValue: knob.min, maxValue: knob.max,
+								  target: self, action: #selector(sliderChanged(_:)))
+			slider.identifier = NSUserInterfaceItemIdentifier(knob.key)
+			slider.isContinuous = true
+			slider.widthAnchor.constraint(equalToConstant: 170).isActive = true
+			let value = label("")
+			value.alignment = .right
+			value.widthAnchor.constraint(equalToConstant: 40).isActive = true
+			sliders[knob.key] = slider
+			valueLabels[knob.key] = value
+			grid.addRow(with: [label(NSLocalizedString(knob.title, comment: "Paper effect parameter name")), slider, value])
+		}
+
+		let reset = NSButton(title: NSLocalizedString("Reset to Cream", comment: "Paper effect: reset to the default preset"),
+							 target: self, action: #selector(resetToDefault(_:)))
+		reset.bezelStyle = .rounded
+		grid.addRow(with: [NSGridCell.emptyContentView, reset, NSGridCell.emptyContentView])
+		grid.column(at: 0).xPlacement = .trailing
+
+		let content = NSView()
+		content.addSubview(grid)
+		NSLayoutConstraint.activate([
+			grid.leadingAnchor.constraint(equalTo: content.leadingAnchor, constant: 20),
+			grid.trailingAnchor.constraint(equalTo: content.trailingAnchor, constant: -20),
+			grid.topAnchor.constraint(equalTo: content.topAnchor, constant: 20),
+			grid.bottomAnchor.constraint(equalTo: content.bottomAnchor, constant: -20),
+		])
+
+		let p = NSPanel(contentRect: NSRect(x: 0, y: 0, width: 380, height: 260),
+						styleMask: [.titled, .closable, .utilityWindow],
+						backing: .buffered, defer: false)
+		p.title = NSLocalizedString("Paper Effect", comment: "Paper effect settings window title")
+		p.isFloatingPanel = true
+		p.hidesOnDeactivate = false
+		p.isReleasedWhenClosed = false
+		p.contentView = content
+		return p
+	}
+
+	private func label(_ string: String) -> NSTextField {
+		NSTextField(labelWithString: string)
+	}
+
+	// MARK: - Sync & actions
+
+	private func syncControls() {
+		let d = UserDefaults.standard
+		for knob in knobs {
+			let v = d.object(forKey: knob.key) != nil ? d.double(forKey: knob.key) : knob.min
+			sliders[knob.key]?.doubleValue = v
+			valueLabels[knob.key]?.stringValue = String(format: "%.2f", v)
+		}
+		updatePresetSelection()
+	}
+
+	@objc private func sliderChanged(_ sender: NSSlider) {
+		guard let key = sender.identifier?.rawValue else { return }
+		UserDefaults.standard.set(sender.doubleValue, forKey: key)
+		valueLabels[key]?.stringValue = String(format: "%.2f", sender.doubleValue)
+		updatePresetSelection()
+		notifyChanged()
+	}
+
+	@objc private func presetChanged(_ sender: NSPopUpButton) {
+		let idx = sender.indexOfSelectedItem
+		guard idx >= 0 && idx < presets.count else { return }  // "Custom" is a no-op
+		let d = UserDefaults.standard
+		for (k, v) in presets[idx].values { d.set(v, forKey: k) }
+		syncControls()
+		notifyChanged()
+	}
+
+	@objc private func resetToDefault(_ sender: Any?) {
+		guard let popup = presetPopup else { return }
+		popup.selectItem(at: 0)
+		presetChanged(popup)
+	}
+
+	private func updatePresetSelection() {
+		let d = UserDefaults.standard
+		let match = presets.firstIndex { preset in
+			preset.values.allSatisfy { abs(d.double(forKey: $0.key) - $0.value) < 0.001 }
+		}
+		presetPopup?.selectItem(at: match ?? presets.count)  // last item = "Custom"
+	}
+
+	private func notifyChanged() {
+		NotificationCenter.default.post(name: SCPaperFilter.settingsChangedNotification, object: nil)
+	}
+}

--- a/Classes/Session/TSSTPageView.h
+++ b/Classes/Session/TSSTPageView.h
@@ -68,6 +68,15 @@ typedef NS_ENUM(NSInteger, DTPageScaling) {
 @property (nonatomic, assign) NSInteger rotation;
 @property (weak) IBOutlet TSSTSessionWindowController * sessionController;
 
+/*!  When YES the pages are rendered through the "paper" image filter
+    (see SCPaperFilter) instead of being drawn verbatim. The original page
+    images are never modified; filtering happens at draw time and is cached. */
+@property (nonatomic) BOOL paperEffect;
+
+/*!  Drops the cached filtered images so the paper effect is recomputed with
+    the current settings on the next draw. Call when the paper parameters change. */
+- (void)invalidatePaperCache;
+
 
 /*!  This is where it all begins sets the two pages.
     Starts any animations

--- a/Classes/Session/TSSTPageView.m
+++ b/Classes/Session/TSSTPageView.m
@@ -54,7 +54,13 @@ typedef struct {
 	NSRect secondPageRect;
 	NSImage	* firstPageImage;
 	NSImage	* secondPageImage;
-	
+
+	//! Cached paper-filtered versions of the page images (see -paperEffect).
+	NSImage	* firstFilteredImage;
+	NSImage	* secondFilteredImage;
+	//! Backing store for the paperEffect property.
+	BOOL paperEffectEnabled;
+
 	TSSTArrowKeys scrollKeys;	//!< Stores which arrow keys are currently depressed. This enables multi axis keyboard scrolling.
 	NSTimer * scrollTimer;		//!< Timer that fires in between each keydown event to smooth out the scrolling.
 	NSDate * interfaceDelay;
@@ -131,6 +137,7 @@ typedef struct {
 	if(first != firstPageImage)
 	{
 		firstPageImage = first;
+		firstFilteredImage = nil;
 		if([self didStartAnimationForImage: firstPageImage])
 		{
 			[sessionController.tracker ocrImage:nil];
@@ -142,6 +149,7 @@ typedef struct {
 	if(second != secondPageImage)
 	{
 		secondPageImage = second;
+		secondFilteredImage = nil;
 		if([self didStartAnimationForImage: secondPageImage])
 		{
 			[sessionController.tracker ocrImage2:nil];
@@ -315,6 +323,65 @@ typedef struct {
 #pragma mark Drawing
 
 
+- (BOOL)paperEffect
+{
+	return paperEffectEnabled;
+}
+
+
+- (void)setPaperEffect:(BOOL)enabled
+{
+	if(paperEffectEnabled != enabled)
+	{
+		paperEffectEnabled = enabled;
+		[self setNeedsDisplay: YES];
+	}
+}
+
+
+- (void)invalidatePaperCache
+{
+	firstFilteredImage = nil;
+	secondFilteredImage = nil;
+	if(paperEffectEnabled)
+	{
+		[self setNeedsDisplay: YES];
+	}
+}
+
+
+/*! Cheap check for multi-frame (animated) images. Such images are drawn
+    unfiltered so their animation keeps working. */
+- (BOOL)isAnimatedImage:(NSImage *)image
+{
+	NSImageRep * rep = [image bestRepresentationForRect: NSZeroRect context: nil hints: nil];
+	if([rep isKindOfClass: [NSBitmapImageRep class]])
+	{
+		return [[(NSBitmapImageRep *)rep valueForProperty: NSImageFrameCount] integerValue] > 1;
+	}
+	return NO;
+}
+
+
+/*! Returns the layer contents for a page: the paper-filtered image (cached)
+    when the effect is on, otherwise the original image. */
+- (id)layerContentsForImage:(NSImage *)image cached:(NSImage * __strong *)cache
+{
+	if(paperEffectEnabled && image && ![self isAnimatedImage: image])
+	{
+		if(!*cache)
+		{
+			*cache = [[SCPaperFilter sharedFilter] paperImageFromImage: image];
+		}
+		if(*cache)
+		{
+			return *cache;
+		}
+	}
+	return image;
+}
+
+
 - (void)drawRect:(NSRect)aRect
 {
 	if(!firstPageImage)
@@ -334,7 +401,7 @@ typedef struct {
 
 	{
 		CALayer *firstPageLayer = [CALayer layer];
-		firstPageLayer.contents = firstPageImage;
+		firstPageLayer.contents = [self layerContentsForImage: firstPageImage cached: &firstFilteredImage];
 		NSRect frame = [self centerScanRect: firstPageRect];
 		[firstPageLayer setFrame:frame];
 		[newLayer addSublayer:firstPageLayer];
@@ -347,7 +414,7 @@ typedef struct {
 	if([secondPageImage isValid])
 	{
 		CALayer *secondPageLayer = [CALayer layer];
-		secondPageLayer.contents = secondPageImage;
+		secondPageLayer.contents = [self layerContentsForImage: secondPageImage cached: &secondFilteredImage];
 		NSRect frame = [self centerScanRect: secondPageRect];
 		[secondPageLayer setFrame:frame];
 		[newLayer addSublayer:secondPageLayer];

--- a/Classes/Session/TSSTSessionWindowController.m
+++ b/Classes/Session/TSSTSessionWindowController.m
@@ -151,6 +151,8 @@ NSString * const TSSTMouseDragNotification = @"SCMouseDragNotification";
 	[defaults addObserver: self forKeyPath: TSSTBackgroundColor options: 0 context: nil];
 	[defaults addObserver: self forKeyPath: TSSTLoupeDiameter options: 0 context: nil];
 	[defaults addObserver: self forKeyPath: TSSTLoupePower options: 0 context: nil];
+	[defaults addObserver: self forKeyPath: SCPaperEffectEnabled options: 0 context: nil];
+	pageView.paperEffect = [defaults boolForKey: SCPaperEffectEnabled];
 	[session addObserver: self forKeyPath: TSSTPageOrder options: 0 context: nil];
 	[session addObserver: self forKeyPath: TSSTPageScaleOptions options: 0 context: nil];
 	[session addObserver: self forKeyPath: TSSTTwoPageSpread options: 0 context: nil];
@@ -180,7 +182,8 @@ NSString * const TSSTMouseDragNotification = @"SCMouseDragNotification";
 	[jumpField setDelegate: self];
 	
 	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleMouseDragged:) name:TSSTMouseDragNotification object:nil];
-	
+	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(paperSettingsChanged:) name:SCPaperFilter.settingsChangedNotification object:nil];
+
 	[self restoreSession];
 }
 
@@ -196,6 +199,7 @@ NSString * const TSSTMouseDragNotification = @"SCMouseDragNotification";
 	[defaults removeObserver: self forKeyPath: TSSTConstrainScale];
 	[defaults removeObserver: self forKeyPath: TSSTLoupeDiameter];
 	[defaults removeObserver: self forKeyPath: TSSTLoupePower];
+	[defaults removeObserver: self forKeyPath: SCPaperEffectEnabled];
 	[pageController removeObserver: self forKeyPath: @"selectionIndex"];
 	[pageController removeObserver: self forKeyPath: @"arrangedObjects.@count"];
 	[[NSNotificationCenter defaultCenter] removeObserver: self];
@@ -280,10 +284,20 @@ NSString * const TSSTMouseDragNotification = @"SCMouseDragNotification";
 	{
 		[self refreshLoupePanel];
 	}
+	else if([keyPath isEqualToString: SCPaperEffectEnabled])
+	{
+		pageView.paperEffect = [defaults boolForKey: SCPaperEffectEnabled];
+	}
 	else
 	{
 		[self changeViewImages];
 	}
+}
+
+
+- (void)paperSettingsChanged:(NSNotification *)note
+{
+	[pageView invalidatePaperCache];
 }
 
 
@@ -689,6 +703,13 @@ NSString * const TSSTMouseDragNotification = @"SCMouseDragNotification";
 	BOOL loupe = session.loupe;
 	loupe = !loupe;
 	session.loupe = loupe;
+}
+
+
+- (IBAction)togglePaperEffect:(id)sender
+{
+	NSUserDefaults * defaults = [NSUserDefaults standardUserDefaults];
+	[defaults setBool: ![defaults boolForKey: SCPaperEffectEnabled] forKey: SCPaperEffectEnabled];
 }
 
 
@@ -1499,6 +1520,11 @@ NSString * const TSSTMouseDragNotification = @"SCMouseDragNotification";
     if([menuItem action] == @selector(toggleFullScreen:))
     {
         state = [[self window] isFullscreen] ? NSControlStateValueOn : NSControlStateValueOff;
+        [menuItem setState: state];
+    }
+    else if([menuItem action] == @selector(togglePaperEffect:))
+    {
+        state = [[NSUserDefaults standardUserDefaults] boolForKey: SCPaperEffectEnabled] ? NSControlStateValueOn : NSControlStateValueOff;
         [menuItem setState: state];
     }
     else if([menuItem action] == @selector(changeTwoPage:))

--- a/Classes/SimpleComicAppDelegate.h
+++ b/Classes/SimpleComicAppDelegate.h
@@ -59,6 +59,7 @@ extern NSString *const TSSTScrollersVisible;
 extern NSString *const TSSTPreserveModDate;
 extern NSString *const TSSTUnifiedTitlebar;
 extern NSString *const TSSTFullscreenToolbar;
+extern NSString *const SCPaperEffectEnabled;
 
 extern NSString *const TSSTScrollPosition;
 extern NSString *const TSSTZoomLevel;

--- a/Classes/SimpleComicAppDelegate.m
+++ b/Classes/SimpleComicAppDelegate.m
@@ -53,6 +53,7 @@ NSString *const TSSTScrollersVisible =  @"scrollersVisible";
 NSString *const TSSTPreserveModDate =   @"preserveModDate";
 NSString *const TSSTUnifiedTitlebar =   @"unifiedTitlebar";
 NSString *const TSSTFullscreenToolbar =   @"fullscreenToolbar";
+NSString *const SCPaperEffectEnabled =    @"SCPaperEffectEnabled";
 
 NSString *const TSSTScrollPosition =    @"scrollPosition";
 NSString *const TSSTZoomLevel =         @"zoomLevel";
@@ -210,6 +211,12 @@ static NSArray<NSNumber*> * allAvailableStringEncodings(void)
 		  TSSTPreserveModDate: @NO,
 		  TSSTUnifiedTitlebar: @NO,
 		  TSSTFullscreenToolbar: @NO,
+		  SCPaperEffectEnabled: @NO,
+		  @"SCPaperShowThrough": @0.38,
+		  @"SCPaperGrain": @0.14,
+		  @"SCPaperWarmth": @1.0,
+		  @"SCPaperBlackLift": @1.0,
+		  @"SCPaperFiberScale": @2.0,
 		  };
 		
 		NSUserDefaultsController * sharedDefaultsController = [NSUserDefaultsController sharedUserDefaultsController];
@@ -738,6 +745,12 @@ static NSArray<NSNumber*> * allAvailableStringEncodings(void)
 		preferences = [DTPreferencesController new];
 	}
 	[preferences showWindow: self];
+}
+
+
+- (IBAction)showPaperSettings:(id)sender
+{
+	[[SCPaperSettingsController sharedController] showPanel: sender];
 }
 
 #pragma mark - Archive Encoding Handling

--- a/Resources/Base.lproj/MainMenu.xib
+++ b/Resources/Base.lproj/MainMenu.xib
@@ -289,6 +289,16 @@ CA
                                     <action selector="toggleLoupe:" target="-1" id="1220"/>
                                 </connections>
                             </menuItem>
+                            <menuItem title="Paper Effect" secondaryImage="newspaper" catalog="system" id="pe1-00-001">
+                                <connections>
+                                    <action selector="togglePaperEffect:" target="-1" id="pe1-00-002"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Paper Effect Settings…" id="pe2-00-001">
+                                <connections>
+                                    <action selector="showPaperSettings:" target="-1" id="pe2-00-002"/>
+                                </connections>
+                            </menuItem>
                             <menuItem title="Thumbnail Exposé" secondaryImage="rectangle.grid.2x2" catalog="system" tag="305" keyEquivalent="t" id="670">
                                 <connections>
                                     <action selector="togglePageExpose:" target="-1" id="1219"/>

--- a/Resources/mul.lproj/MainMenu.xcstrings
+++ b/Resources/mul.lproj/MainMenu.xcstrings
@@ -5304,6 +5304,30 @@
           }
         }
       }
+    },
+    "pe1-00-001.title" : {
+      "comment" : "Class = \"NSMenuItem\"; title = \"Paper Effect\"; ObjectID = \"pe1-00-001\";",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Paper Effect"
+          }
+        }
+      }
+    },
+    "pe2-00-001.title" : {
+      "comment" : "Class = \"NSMenuItem\"; title = \"Paper Effect Settings…\"; ObjectID = \"pe2-00-001\";",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Paper Effect Settings…"
+          }
+        }
+      }
     }
   },
   "version" : "1.0"

--- a/SimpleComic.xcodeproj/project.pbxproj
+++ b/SimpleComic.xcodeproj/project.pbxproj
@@ -25,6 +25,9 @@
 		28A266161285C3A700ED6391 /* TSSTSessionWindow.xib in Resources */ = {isa = PBXBuildFile; fileRef = 28A266141285C3A700ED6391 /* TSSTSessionWindow.xib */; };
 		28A266301285C73200ED6391 /* DTPreferencesController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28A2662F1285C73200ED6391 /* DTPreferencesController.swift */; };
 		28B34A731013779B006C551C /* NSWindow+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28B34A721013779B006C551C /* NSWindow+Extensions.swift */; };
+		5C0FA9E100000000000000A2 /* SCPaperFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C0FA9E100000000000000A1 /* SCPaperFilter.swift */; };
+		5C0FA9E100000000000000C2 /* SCPaperSettingsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C0FA9E100000000000000C1 /* SCPaperSettingsController.swift */; };
+		5C0FA9E100000000000000B2 /* PaperKernels.metal in Sources */ = {isa = PBXBuildFile; fileRef = 5C0FA9E100000000000000B1 /* PaperKernels.metal */; settings = {COMPILER_FLAGS = "-fcikernel"; }; };
 		28BD08E60C9836E600BD7EAF /* Quartz.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28BD08E50C9836E600BD7EAF /* Quartz.framework */; };
 		28C1D4080DF18251003392B4 /* TSSTManagedSession.m in Sources */ = {isa = PBXBuildFile; fileRef = 2803B2FF0D5E541800CD7906 /* TSSTManagedSession.m */; };
 		28C1D5600DF1FE37003392B4 /* QuickLook.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28C1D55F0DF1FE37003392B4 /* QuickLook.framework */; };
@@ -366,6 +369,9 @@
 		28A2662F1285C73200ED6391 /* DTPreferencesController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DTPreferencesController.swift; sourceTree = "<group>"; };
 		28A8EAB00B412DE5006C036D /* TSSTPageView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TSSTPageView.h; sourceTree = "<group>"; };
 		28B34A721013779B006C551C /* NSWindow+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSWindow+Extensions.swift"; sourceTree = "<group>"; };
+		5C0FA9E100000000000000A1 /* SCPaperFilter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SCPaperFilter.swift; sourceTree = "<group>"; };
+		5C0FA9E100000000000000C1 /* SCPaperSettingsController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SCPaperSettingsController.swift; sourceTree = "<group>"; };
+		5C0FA9E100000000000000B1 /* PaperKernels.metal */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.metal; path = PaperKernels.metal; sourceTree = "<group>"; };
 		28BD08E50C9836E600BD7EAF /* Quartz.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quartz.framework; path = System/Library/Frameworks/Quartz.framework; sourceTree = SDKROOT; };
 		28C1D55F0DF1FE37003392B4 /* QuickLook.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuickLook.framework; path = System/Library/Frameworks/QuickLook.framework; sourceTree = SDKROOT; };
 		28EF3FBE0E9970BD002AD2EE /* UKXattrMetadataStore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UKXattrMetadataStore.h; sourceTree = "<group>"; };
@@ -854,6 +860,9 @@
 				FA7257EF08A6CE2E006A2A19 /* TSSTPageView.m */,
 				284D381A101249BE00A37AB2 /* DTToolbarItems.swift */,
 				28B34A721013779B006C551C /* NSWindow+Extensions.swift */,
+				5C0FA9E100000000000000A1 /* SCPaperFilter.swift */,
+				5C0FA9E100000000000000C1 /* SCPaperSettingsController.swift */,
+				5C0FA9E100000000000000B1 /* PaperKernels.metal */,
 				6304B5C2284018E9009E7D61 /* OCRVision */,
 			);
 			path = Session;
@@ -1302,6 +1311,9 @@
 				554A1C0226478396009FE60D /* TSSTSessionWindowController+NSTouchBar.swift in Sources */,
 				5538C2021C0E1A7C00744130 /* TSSTInfoView.swift in Sources */,
 				28B34A731013779B006C551C /* NSWindow+Extensions.swift in Sources */,
+				5C0FA9E100000000000000A2 /* SCPaperFilter.swift in Sources */,
+				5C0FA9E100000000000000C2 /* SCPaperSettingsController.swift in Sources */,
+				5C0FA9E100000000000000B2 /* PaperKernels.metal in Sources */,
 				5526278D1BDEBF29005AAF63 /* TSSTImageView.swift in Sources */,
 				287D0C1210F0595900207768 /* Sessions_DataModel.xcdatamodel in Sources */,
 				8FBFF02E26EF71BF00E3CFC8 /* TSSTSessionWindowController+NSToolbarDelegate.swift in Sources */,
@@ -1714,6 +1726,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 55E21B1123FBCCF900D53932 /* No Sign.xcconfig */;
 			buildSettings = {
+				MTLLINKER_FLAGS = "-cikernel";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = "Accent Color";
 				CLANG_ENABLE_MODULES = YES;
@@ -1753,6 +1766,7 @@
 		FA7257E408A6CDEB006A2A19 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				MTLLINKER_FLAGS = "-cikernel";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = "Accent Color";
 				CLANG_ENABLE_MODULES = YES;


### PR DESCRIPTION
Renders comic pages to look like ink on paper instead of a backlit screen, toggled from View > Paper Effect (off by default).

- SCPaperFilter: a non-destructive Core Image pipeline applied at draw time in TSSTPageView (originals untouched, results cached, animated images skipped). A warm-cream tonal remap lifts pure black to a dark warm grey and pulls white to a cream stock.
- PaperKernels.metal (paperTexture CIKernel): an even, isotropic paper grain applied two ways at once — a multiply "body" on the light stock plus a screen "show-through" so the paper peeks through dense ink. The .metal is compiled with -fcikernel and linked with -cikernel (MTLLINKER_FLAGS); SCPaperFilter falls back to a pure Core Image approximation if the kernel can not be loaded.
- SCPaperSettingsController: a floating panel (View > Paper Effect Settings…) with live sliders (show-through, grain, warmth, black lift) and Cream / Newsprint / Manga / E-Ink presets, backed by NSUserDefaults.

<img width="268" height="321" alt="Bildschirmfoto 2026-07-06 um 13 55 26" src="https://github.com/user-attachments/assets/4e021742-254f-4c3b-b1ef-dab076418548" />
<img width="267" height="322" alt="Bildschirmfoto 2026-07-06 um 13 55 19" src="https://github.com/user-attachments/assets/28c166cc-fefd-4cdb-828c-2cced8588707" />


<img width="440" height="330" alt="Bildschirmfoto 2026-07-06 um 13 55 39" src="https://github.com/user-attachments/assets/9613c99c-089a-44e2-9a72-5e464127a353" />

